### PR TITLE
feat(server): add support for changing a users password

### DIFF
--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/SecurityConfig.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/SecurityConfig.java
@@ -70,6 +70,8 @@ class SecurityConfig {
                     .authenticated()
                     .requestMatchers(HttpMethod.POST, "/api/v1/agents/*/reports")
                     .hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.PUT, "/api/users/*/password")
+                    .authenticated()
                     .requestMatchers(
                         "/",
                         "/index.html",

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/CustomUserDetails.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/CustomUserDetails.java
@@ -11,7 +11,7 @@ public class CustomUserDetails implements UserDetails {
   private final String password;
 
   CustomUserDetails(User user) {
-    this.user = new UserDTO(user.getUsername(), user.getId().toString());
+    this.user = new UserDTO(user.getUsername(), user.getId());
     this.password = user.getPassword();
     this.user.setRoles(user.getRoles());
   }

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/PasswordChangeRequest.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/PasswordChangeRequest.java
@@ -1,0 +1,70 @@
+package eu.bbmri_eric.quality.server.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "Request object for changing user password")
+public class PasswordChangeRequest {
+
+  @Schema(
+      description = "Current password of the user",
+      example = "oldPassword123",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String currentPassword;
+
+  @Pattern(
+      regexp = "^[a-zA-Z0-9!@#$%^&*(),.?\":{}|<>_-]{8,}$",
+      message =
+          "Password must be at least 8 characters long and contain only letters, digits or special characters")
+  @Schema(
+      description = "New password for the user",
+      example = "newPassword123!",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String newPassword;
+
+  @Pattern(
+      regexp = "^[a-zA-Z0-9!@#$%^&*(),.?\":{}|<>_-]{8,}$",
+      message =
+          "Password must be at least 8 characters long and contain only letters, digits or special characters")
+  @Schema(
+      description = "Confirmation of the new password",
+      example = "newPassword123!",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String confirmPassword;
+
+  public PasswordChangeRequest(String currentPassword, String newPassword, String confirmPassword) {
+    this.currentPassword = currentPassword;
+    this.newPassword = newPassword;
+    this.confirmPassword = confirmPassword;
+  }
+
+  public String getCurrentPassword() {
+    return currentPassword;
+  }
+
+  public void setCurrentPassword(String currentPassword) {
+    this.currentPassword = currentPassword;
+  }
+
+  public String getNewPassword() {
+    return newPassword;
+  }
+
+  public void setNewPassword(String newPassword) {
+    this.newPassword = newPassword;
+  }
+
+  public String getConfirmPassword() {
+    return confirmPassword;
+  }
+
+  public void setConfirmPassword(String confirmPassword) {
+    this.confirmPassword = confirmPassword;
+  }
+
+  public void validate() {
+    if (!newPassword.equals(confirmPassword)) {
+      throw new IllegalArgumentException("New password and confirmation do not match");
+    }
+  }
+}

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/User.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/User.java
@@ -136,4 +136,8 @@ class User {
   public String toString() {
     return "User{username='" + username + "'}";
   }
+
+  public void setPassword(String encodedPassword) {
+    this.password = encodedPassword;
+  }
 }

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/UserController.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/UserController.java
@@ -1,0 +1,37 @@
+package eu.bbmri_eric.quality.server.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "User Management", description = "APIs for user authentication and password management")
+public class UserController {
+
+  private final UserService userService;
+
+  public UserController(UserService userService) {
+    this.userService = userService;
+  }
+
+  @Operation(
+      summary = "Change user password",
+      description = "Changes the password for a specific user.")
+  @PutMapping("/api/users/{userId}/password")
+  public void changePassword(
+      @Parameter(
+              description = "ID of the user whose password should be changed.",
+              required = true,
+              example = "1")
+          @PathVariable
+          Long userId,
+      @Parameter(description = "Password change request", required = true) @Valid @RequestBody
+          PasswordChangeRequest request) {
+    userService.changePassword(userId, request);
+  }
+}

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/UserDTO.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/UserDTO.java
@@ -18,7 +18,7 @@ public class UserDTO {
   private String username;
 
   @Schema(description = "Unique identifier for the user", example = "user123")
-  private String id;
+  private Long id;
 
   @Schema(description = "Temporary password", example = "123")
   private String temporaryPassword;
@@ -28,9 +28,7 @@ public class UserDTO {
 
   private Set<UserRole> roles;
 
-  public UserDTO(
-      @NotEmpty(message = "Username cannot be empty") String username,
-      @NotEmpty(message = "ID cannot be empty") String id) {
+  public UserDTO(@NotEmpty(message = "Username cannot be empty") String username, Long id) {
     this.username = username;
     this.id = id;
   }
@@ -47,11 +45,11 @@ public class UserDTO {
     this.username = username;
   }
 
-  public String getId() {
+  public Long getId() {
     return id;
   }
 
-  public void setId(String id) {
+  public void setId(Long id) {
     this.id = id;
   }
 

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/UserService.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/UserService.java
@@ -2,4 +2,12 @@ package eu.bbmri_eric.quality.server.user;
 
 public interface UserService {
   UserDTO createUser(UserCreateDTO userCreateDTO);
+
+  /**
+   * Change the password of a user. Users can only change their own password.
+   *
+   * @param userId the ID of the user whose password should be changed
+   * @param passwordChangeRequest dto containing current password, new password, and confirmation
+   */
+  void changePassword(Long userId, PasswordChangeRequest passwordChangeRequest);
 }

--- a/server/backend/src/test/java/eu/bbmri_eric/quality/server/user/UserControllerTest.java
+++ b/server/backend/src/test/java/eu/bbmri_eric/quality/server/user/UserControllerTest.java
@@ -1,0 +1,274 @@
+package eu.bbmri_eric.quality.server.user;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri_eric.quality.server.auth.LoginRequest;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class UserControllerTest {
+
+  private static final String AUTH_LOGIN_ENDPOINT = "/api/auth/login";
+  private static final String ADMIN_USER = "admin";
+  private static final String ADMIN_PASS = "adminpass";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private UserRepository userRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @AfterEach
+  void tearDown() {
+    User adminUser =
+        userRepository.findByUsername(ADMIN_USER).orElseThrow(EntityNotFoundException::new);
+    adminUser.setPassword(passwordEncoder.encode(ADMIN_PASS));
+    userRepository.save(adminUser);
+  }
+
+  @Test
+  void login_correctCredentials_returnsTokenAndUserInfo() throws Exception {
+    LoginRequest loginRequest = new LoginRequest(ADMIN_USER, ADMIN_PASS);
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.token").exists())
+        .andExpect(jsonPath("$.token").isNotEmpty())
+        .andExpect(jsonPath("$.user.username", is(ADMIN_USER)));
+  }
+
+  @Test
+  void login_invalidCredentials_returnsUnauthorized() throws Exception {
+    LoginRequest loginRequest = new LoginRequest(ADMIN_USER, "wrongpassword");
+
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void login_invalidUsername_returnsUnauthorized() throws Exception {
+    LoginRequest loginRequest = new LoginRequest("nonexistent", ADMIN_PASS);
+
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void login_emptyCredentials_returnsBadRequest() throws Exception {
+    LoginRequest loginRequest = new LoginRequest("", "");
+
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void login_nullCredentials_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(post(AUTH_LOGIN_ENDPOINT).contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void login_invalidContentType_returnsUnsupportedMediaType() throws Exception {
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT).contentType(MediaType.TEXT_PLAIN).content("invalid content"))
+        .andExpect(status().isUnsupportedMediaType());
+  }
+
+  @Test
+  void login_malformedJson_returnsBadRequest() throws Exception {
+    String malformedJson = "{invalid json";
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(malformedJson))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void changePassword_withValidToken_returnsOk() throws Exception {
+    String token = authenticateAndGetToken();
+
+    User adminUser = userRepository.findByUsername(ADMIN_USER).orElseThrow();
+    Long adminUserId = adminUser.getId();
+
+    String newPassword = "newPass123!";
+    PasswordChangeRequest request =
+        new PasswordChangeRequest("adminpass", newPassword, newPassword);
+
+    mockMvc
+        .perform(
+            put("/api/users/" + adminUserId + "/password")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk());
+    LoginRequest loginRequest = new LoginRequest(ADMIN_USER, newPassword);
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.token").exists())
+        .andExpect(jsonPath("$.token").isNotEmpty())
+        .andExpect(jsonPath("$.user.username", is(ADMIN_USER)));
+  }
+
+  @Test
+  void changePassword_withInvalidToken_returnsUnauthorized() throws Exception {
+    PasswordChangeRequest request =
+        new PasswordChangeRequest("current", "newPass123!", "newPass123!");
+
+    mockMvc
+        .perform(
+            put("/api/users/1/password")
+                .header("Authorization", "Bearer invalid-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void changePassword_withoutToken_returnsUnauthorized() throws Exception {
+    PasswordChangeRequest request =
+        new PasswordChangeRequest("current", "newPass123!", "newPass123!");
+
+    mockMvc
+        .perform(
+            put("/api/users/1/password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void changePassword_withValidToken_invalidPasswordFormat_returnsBadRequest() throws Exception {
+    String token = authenticateAndGetToken();
+
+    User adminUser = userRepository.findByUsername(ADMIN_USER).orElseThrow();
+    Long adminUserId = adminUser.getId();
+
+    PasswordChangeRequest request = new PasswordChangeRequest("adminpass", "short", "short");
+
+    mockMvc
+        .perform(
+            put("/api/users/" + adminUserId + "/password")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void changePassword_tryingToChangeOtherUserPassword_returnsForbidden() throws Exception {
+    String token = authenticateAndGetToken();
+    long otherUserId = -1L;
+
+    PasswordChangeRequest request =
+        new PasswordChangeRequest("adminpass", "newPass123!", "newPass123!");
+
+    mockMvc
+        .perform(
+            put("/api/users/" + otherUserId + "/password")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void tokenGeneration_validLoginReturnsJwtToken() throws Exception {
+    String token = authenticateAndGetToken();
+
+    // Verify the token is not null and has the expected JWT structure
+    assertNotNull(token, "Token should not be null");
+    assertEquals(3, token.split("\\.").length, "JWT token should have 3 parts separated by dots");
+    assertTrue(
+        token.startsWith("eyJ"), "JWT token should start with 'eyJ' (Base64 encoded header)");
+  }
+
+  @Test
+  void tokenAuthentication_validTokenAllowsApiAccess() throws Exception {
+    String token = authenticateAndGetToken();
+
+    User adminUser = userRepository.findByUsername(ADMIN_USER).orElseThrow();
+    Long adminUserId = adminUser.getId();
+
+    // Use the token to access a protected endpoint
+    mockMvc
+        .perform(
+            put("/api/users/" + adminUserId + "/password")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new PasswordChangeRequest("adminpass", "newPass123!", "newPass123!"))))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void tokenAuthentication_expiredOrInvalidTokenDeniesAccess() throws Exception {
+    // Test with completely invalid token
+    mockMvc
+        .perform(
+            put("/api/users/1/password")
+                .header("Authorization", "Bearer totally-invalid-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new PasswordChangeRequest("current", "newPass123!", "newPass123!"))))
+        .andExpect(status().isUnauthorized());
+  }
+
+  /** Helper method to authenticate and extract JWT token from response */
+  private String authenticateAndGetToken() throws Exception {
+    LoginRequest loginRequest = new LoginRequest(ADMIN_USER, ADMIN_PASS);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post(AUTH_LOGIN_ENDPOINT)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(loginRequest)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String responseContent = result.getResponse().getContentAsString();
+    var response = objectMapper.readTree(responseContent);
+    return response.get("token").asText();
+  }
+}

--- a/server/frontend/src/components/Sidebar.vue
+++ b/server/frontend/src/components/Sidebar.vue
@@ -30,10 +30,16 @@
           <i class="bi bi-clipboard-check-fill"></i>
           <span>Quality Checks</span>
         </router-link>
-        <router-link to="/settings" class="nav-link" :class="{ active: $route.name === 'Settings' }" @click="closeMobileMenu">
-          <i class="bi bi-gear-fill"></i>
-          <span>Settings</span>
-        </router-link>
+        <div class="nav-section">
+          <div class="nav-section-header">
+            <i class="bi bi-gear-fill"></i>
+            <span>Settings</span>
+          </div>
+          <router-link to="/profile" class="nav-link nav-subitem" :class="{ active: $route.name === 'Profile' }" @click="closeMobileMenu">
+            <i class="bi bi-person-fill"></i>
+            <span>Profile</span>
+          </router-link>
+        </div>
       </nav>
     </div>
   </aside>
@@ -185,6 +191,39 @@ const closeMobileMenu = () => {
   height: 60%;
   background: white;
   border-radius: 0 4px 4px 0;
+}
+
+/* Navigation Section */
+.nav-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.nav-section-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 1rem;
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: default;
+}
+
+.nav-section-header i {
+  font-size: 1.25rem;
+  min-width: 1.25rem;
+}
+
+.nav-subitem {
+  margin-left: 1rem;
+  padding-left: 2.25rem !important;
+  font-size: 0.9rem;
+}
+
+.nav-subitem i {
+  font-size: 1.125rem !important;
 }
 
 /* Mobile Menu Toggle */

--- a/server/frontend/src/router/index.js
+++ b/server/frontend/src/router/index.js
@@ -4,6 +4,7 @@ import { authStore } from '../stores/authStore.js'
 import Dashboard from '../views/Dashboard.vue'
 import Reports from '../views/Reports.vue'
 import Settings from '../views/Settings.vue'
+import Profile from '../views/Profile.vue'
 import AgentsView from '../views/AgentsView.vue'
 import AgentReportView from '../views/AgentReportView.vue'
 import AgentInteractionsView from '../views/AgentInteractionsView.vue'
@@ -51,6 +52,12 @@ const routes = [
     path: '/settings',
     name: 'Settings',
     component: Settings,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/profile',
+    name: 'Profile',
+    component: Profile,
     meta: { requiresAuth: true }
   },
   {

--- a/server/frontend/src/services/apiService.js
+++ b/server/frontend/src/services/apiService.js
@@ -151,6 +151,26 @@ class ApiService {
         }
         return await response.json()
     }
+
+    async changePassword(userId, currentPassword, newPassword, confirmPassword) {
+        const token = localStorage.getItem('authToken')
+        const response = await fetch(`${API_BASE}/users/${userId}/password`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(token && { 'Authorization': `Bearer ${token}` })
+            },
+            body: JSON.stringify({
+                currentPassword,
+                newPassword,
+                confirmPassword
+            })
+        })
+        if (!response.ok) {
+            const errorText = await response.text()
+            throw new Error(errorText || `Failed to change password: ${response.status}`)
+        }
+    }
 }
 
 export const apiService = new ApiService()

--- a/server/frontend/src/views/Profile.vue
+++ b/server/frontend/src/views/Profile.vue
@@ -1,0 +1,247 @@
+<template>
+  <div class="container-fluid py-3 py-md-4">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-8">
+        <h2 class="h4 h-md-3 fw-bold text-dark mb-3 mb-md-4">Profile</h2>
+
+        <!-- User Information Card -->
+        <div class="card border-0 shadow-sm mb-4">
+          <div class="card-body p-4">
+            <h3 class="h5 fw-bold mb-3">User Information</h3>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label class="form-label text-muted small">Username</label>
+                <p class="fw-semibold mb-0">{{ user?.username || 'N/A' }}</p>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label text-muted small">User ID</label>
+                <p class="fw-semibold mb-0">{{ user?.id || 'N/A' }}</p>
+              </div>
+              <div class="col-md-6" v-if="user?.agentId">
+                <label class="form-label text-muted small">Agent ID</label>
+                <p class="fw-semibold mb-0">{{ user.agentId }}</p>
+              </div>
+              <div class="col-md-6" v-if="user?.roles && user.roles.length > 0">
+                <label class="form-label text-muted small">Roles</label>
+                <p class="fw-semibold mb-0">
+                  <span v-for="role in user.roles" :key="role" class="badge bg-primary me-1">
+                    {{ role }}
+                  </span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Change Password Card -->
+        <div class="card border-0 shadow-sm">
+          <div class="card-body p-4">
+            <h3 class="h5 fw-bold mb-3">Change Password</h3>
+
+            <form @submit.prevent="handlePasswordChange">
+              <div class="mb-3">
+                <label for="currentPassword" class="form-label">Current Password</label>
+                <input
+                  type="password"
+                  class="form-control"
+                  :class="{ 'is-invalid': errors.currentPassword }"
+                  id="currentPassword"
+                  v-model="passwordForm.currentPassword"
+                  required
+                  autocomplete="current-password"
+                >
+                <div class="invalid-feedback" v-if="errors.currentPassword">
+                  {{ errors.currentPassword }}
+                </div>
+              </div>
+
+              <div class="mb-3">
+                <label for="newPassword" class="form-label">New Password</label>
+                <input
+                  type="password"
+                  class="form-control"
+                  :class="{ 'is-invalid': errors.newPassword }"
+                  id="newPassword"
+                  v-model="passwordForm.newPassword"
+                  required
+                  autocomplete="new-password"
+                >
+                <div class="invalid-feedback" v-if="errors.newPassword">
+                  {{ errors.newPassword }}
+                </div>
+                <div class="form-text">
+                  Password must be at least 8 characters long and contain only letters, digits or special characters.
+                </div>
+              </div>
+
+              <div class="mb-3">
+                <label for="confirmPassword" class="form-label">Confirm New Password</label>
+                <input
+                  type="password"
+                  class="form-control"
+                  :class="{ 'is-invalid': errors.confirmPassword }"
+                  id="confirmPassword"
+                  v-model="passwordForm.confirmPassword"
+                  required
+                  autocomplete="new-password"
+                >
+                <div class="invalid-feedback" v-if="errors.confirmPassword">
+                  {{ errors.confirmPassword }}
+                </div>
+              </div>
+
+              <div class="d-flex gap-2">
+                <button
+                  type="submit"
+                  class="btn btn-primary"
+                  :disabled="isSubmitting"
+                >
+                  <span v-if="isSubmitting" class="spinner-border spinner-border-sm me-2"></span>
+                  {{ isSubmitting ? 'Changing...' : 'Change Password' }}
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  @click="resetForm"
+                  :disabled="isSubmitting"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, computed, ref } from 'vue'
+import { authStore } from '../stores/authStore.js'
+import { apiService } from '../services/apiService.js'
+import { notificationService } from '../services/notificationService.js'
+
+const user = computed(() => authStore.user)
+
+const passwordForm = reactive({
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: ''
+})
+
+const errors = reactive({
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: ''
+})
+
+const isSubmitting = ref(false)
+
+const validatePasswordForm = () => {
+  // Clear previous errors
+  errors.currentPassword = ''
+  errors.newPassword = ''
+  errors.confirmPassword = ''
+
+  let isValid = true
+
+  // Validate current password
+  if (!passwordForm.currentPassword.trim()) {
+    errors.currentPassword = 'Current password is required'
+    isValid = false
+  }
+
+  // Validate new password
+  if (!passwordForm.newPassword.trim()) {
+    errors.newPassword = 'New password is required'
+    isValid = false
+  } else if (passwordForm.newPassword.length < 8) {
+    errors.newPassword = 'Password must be at least 8 characters long'
+    isValid = false
+  } else if (!/^[a-zA-Z0-9!@#$%^&*(),.?":{}|<>_-]{8,}$/.test(passwordForm.newPassword)) {
+    errors.newPassword = 'Password contains invalid characters'
+    isValid = false
+  }
+
+  // Validate confirm password
+  if (!passwordForm.confirmPassword.trim()) {
+    errors.confirmPassword = 'Please confirm your new password'
+    isValid = false
+  } else if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+    errors.confirmPassword = 'Passwords do not match'
+    isValid = false
+  }
+
+  return isValid
+}
+
+const handlePasswordChange = async () => {
+  if (!validatePasswordForm()) {
+    return
+  }
+
+  if (!user.value?.id) {
+    notificationService.error('Error', 'User ID not found')
+    return
+  }
+
+  isSubmitting.value = true
+
+  try {
+    await apiService.changePassword(
+      user.value.id,
+      passwordForm.currentPassword,
+      passwordForm.newPassword,
+      passwordForm.confirmPassword
+    )
+
+    notificationService.success(
+      'Password Changed',
+      'Your password has been successfully updated'
+    )
+
+    resetForm()
+  } catch (error) {
+    console.error('Password change failed:', error)
+    notificationService.error(
+      'Password Change Failed',
+      error.message || 'Unable to change password. Please check your current password and try again.'
+    )
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+const resetForm = () => {
+  passwordForm.currentPassword = ''
+  passwordForm.newPassword = ''
+  passwordForm.confirmPassword = ''
+  errors.currentPassword = ''
+  errors.newPassword = ''
+  errors.confirmPassword = ''
+}
+</script>
+
+<style scoped>
+.badge {
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+.form-label {
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.card {
+  border-radius: 12px;
+}
+
+@media (max-width: 768px) {
+  .card-body {
+    padding: 1.5rem !important;
+  }
+}
+</style>
+


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces a secure user password change feature to the backend API, updates user data handling, and enhances frontend navigation. The most significant changes include the addition of a password change endpoint, supporting request/response models, service and security updates, and comprehensive tests for authentication and password management.

**Backend: User password change feature**

* Added a new `PasswordChangeRequest` DTO with validation and matching logic for password changes.
* Introduced a `UserController` with a `PUT /api/users/{userId}/password` endpoint to handle password changes, restricted to authenticated users changing their own password. [[1]](diffhunk://#diff-9a265fa0e0e3bd81997e27d7e112177518831117748de59eb9238846064ab5b7R1-R37) [[2]](diffhunk://#diff-7d4c425306223159cbe867661d3a918960588810d37e788f58831dac87122357R73-R74)
* Implemented `changePassword` in `UserService` and `UserServiceImpl`, including current password verification, new password validation, and proper error handling. [[1]](diffhunk://#diff-be42aaf9fb414b3ac2d91ca58832b30b76394a0c5fc51574c81d9e632e66ac0dR5-R12) [[2]](diffhunk://#diff-1c7e96511843f3a39edfee6a8e07721dac7f6b3242cd0b257fce269a1172e91cR23-R33) [[3]](diffhunk://#diff-1c7e96511843f3a39edfee6a8e07721dac7f6b3242cd0b257fce269a1172e91cR46-R68)
* Updated `User` entity to allow password updates via a setter.

**User data model improvements**

* Changed `UserDTO` and related usages to use `Long` for user IDs instead of `String`, improving type safety. [[1]](diffhunk://#diff-20fe8abfcdaff0e08180b633c31e54ee2dc577961c115327eff7df2f8c19f5e7L21-R21) [[2]](diffhunk://#diff-20fe8abfcdaff0e08180b633c31e54ee2dc577961c115327eff7df2f8c19f5e7L31-R31) [[3]](diffhunk://#diff-20fe8abfcdaff0e08180b633c31e54ee2dc577961c115327eff7df2f8c19f5e7L50-R52) [[4]](diffhunk://#diff-ddb236787967145d5d4ddd6a4f45868f9804882320ab7076641d37e33e0c0675L14-R14)

**Security and access control**

* Updated security configuration to allow authenticated users to access the new password change endpoint.

**Testing**

* Added comprehensive integration tests in `UserControllerTest` to cover login, authentication, and password change scenarios, including error cases and token validation.

**Frontend: Navigation update**

* Improved the sidebar navigation by grouping settings and adding a dedicated "Profile" link under a "Settings" section, with corresponding styles. [[1]](diffhunk://#diff-03fbd94119cc5794c15177f415f3ea66b9c602c1dc07c25c4de74c1e27ea4bb4L33-R42) [[2]](diffhunk://#diff-03fbd94119cc5794c15177f415f3ea66b9c602c1dc07c25c4de74c1e27ea4bb4R196-R228)

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
