### PR TITLE
fix(server): add support for jwt+at tokens

### DIFF
--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/auth/CustomAuthenticationManagerResolver.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/auth/CustomAuthenticationManagerResolver.java
@@ -3,6 +3,7 @@ package eu.bbmri_eric.quality.server.common.auth;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,9 +12,14 @@ import org.springframework.security.authentication.AuthenticationManagerResolver
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
@@ -54,7 +60,8 @@ class CustomAuthenticationManagerResolver
 
     if (oidcIssuerUri != null && !oidcIssuerUri.isBlank()) {
       try {
-        JwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(oidcIssuerUri);
+        NimbusJwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(oidcIssuerUri);
+        jwtDecoder.setJwtValidator(getJwtOAuth2TokenValidator());
         JwtAuthenticationProvider oidcProvider = new JwtAuthenticationProvider(jwtDecoder);
         oidcProvider.setJwtAuthenticationConverter(jwtAuthenticationConverter);
         AuthenticationManager oidcAuthManager = new ProviderManager(oidcProvider);
@@ -94,5 +101,20 @@ class CustomAuthenticationManagerResolver
       throw new IllegalStateException(
           "Failed to resolve AuthenticationManager: " + e.getMessage(), e);
     }
+  }
+
+  private static @NonNull OAuth2TokenValidator<Jwt> getJwtOAuth2TokenValidator() {
+    return jwt -> {
+      Object typObj = jwt.getHeaders().get("typ");
+      if (typObj == null) {
+        return OAuth2TokenValidatorResult.success();
+      }
+      String typ = typObj.toString();
+      if ("JWT".equalsIgnoreCase(typ) || "at+jwt".equalsIgnoreCase(typ)) {
+        return OAuth2TokenValidatorResult.success();
+      }
+      return OAuth2TokenValidatorResult.failure(
+          new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN, "Unsupported JOSE typ: " + typ, null));
+    };
   }
 }


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request updates the authentication logic in `CustomAuthenticationManagerResolver.java` to improve JWT token validation and ensure only supported token types are accepted. The main changes involve adding a custom JWT validator and updating dependencies to support this validation.

**Authentication and JWT validation improvements:**

* Introduced a custom `OAuth2TokenValidator<Jwt>` via the new `getJwtOAuth2TokenValidator()` method, which checks the JWT header's `typ` field and only allows tokens of type `JWT` or `at+jwt`. Tokens with unsupported types are rejected as invalid.
* Updated the JWT decoder instantiation to use `NimbusJwtDecoder` and applied the custom validator to it, ensuring stricter token validation during authentication.

**Dependency and import updates:**

* Added imports for `OAuth2Error`, `OAuth2ErrorCodes`, `OAuth2TokenValidator`, `OAuth2TokenValidatorResult`, `Jwt`, and `NimbusJwtDecoder` to support custom JWT validation logic.
* Added the `@NonNull` annotation import from `org.jspecify.annotations` to improve type safety in the new validator method.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [ ] I have performed a self-review of my code
- [ ] I have made my code as simple as possible
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [ ] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
