### PR TITLE
chore: add all-other-java and all-other-npm update configurations for…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,11 @@ updates:
           - "com.fasterxml*"
         update-types:
           - "major"
+      all-other-java:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "maven"
     directory: "/server/backend"
@@ -105,6 +110,11 @@ updates:
           - "org.projectlombok*"
           - "com.google*"
           - "com.fasterxml*"
+        update-types:
+          - "major"
+      all-other-java:
+        patterns:
+          - "*"
         update-types:
           - "major"
 
@@ -154,12 +164,9 @@ updates:
           - "pinia*"
         update-types:
           - "major"
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "major"
-      production-dependencies:
-        dependency-type: "production"
+      all-other-npm:
+        patterns:
+          - "*"
         update-types:
           - "major"
 
@@ -209,12 +216,9 @@ updates:
           - "pinia*"
         update-types:
           - "major"
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "major"
-      production-dependencies:
-        dependency-type: "production"
+      all-other-npm:
+        patterns:
+          - "*"
         update-types:
           - "major"
 
@@ -238,12 +242,9 @@ updates:
           - "@vitepress*"
         update-types:
           - "major"
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "major"
-      production-dependencies:
-        dependency-type: "production"
+      all-other-npm:
+        patterns:
+          - "*"
         update-types:
           - "major"
 


### PR DESCRIPTION
… major version updates

## Pull Request:

### Description:

This pull request updates the `.github/dependabot.yml` configuration to simplify and generalize how major updates are managed for both Java (Maven) and npm dependencies. The changes consolidate previous separate rules for development and production dependencies into a single catch-all rule for each package ecosystem, making the configuration easier to maintain and ensuring all major updates are captured.

**Dependabot configuration simplification:**

* Added a new `all-other-java` group with a wildcard pattern to include all other Java dependencies for major updates, reducing the need for individually specified rules. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R66-R70) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R115-R119)
* Replaced separate `development-dependencies` and `production-dependencies` groups for npm with a single `all-other-npm` group using a wildcard pattern, streamlining update management for all npm dependencies. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L157-R169) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L212-R221) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L241-R247)

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [ ] I have performed a self-review of my code
- [ ] I have made my code as simple as possible
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [ ] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
