### PR TITLE
feat(docs): add matomo analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,9 @@ jobs:
     name: Documentation Build and Deployment
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
+    env:
+      MATOMO_BASE_URL: 'https://matomo.bbmri-eric.eu/'
+      MATOMO_SITE_ID: '12'
     permissions:
       contents: read
       pages: write

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,6 +1,6 @@
 import {defineConfig} from 'vitepress'
 import {getLatestVersionSync} from './version.js'
-import {createMatomoPlugin} from './plugins/vitepress-plugin-matomo.js'
+import {createMatomoConfigEntries} from './plugins/vitepress-plugin-matomo.js'
 
 const version = getLatestVersionSync();
 
@@ -149,9 +149,9 @@ export default defineConfig({
         }],
         ['meta', {name: 'twitter:card', content: 'summary_large_image'}],
         ['meta', {name: 'twitter:image', content: '/logo.svg'}],
-        ...createMatomoPlugin({
+        ...createMatomoConfigEntries({
             baseUrl: process.env.MATOMO_BASE_URL ?? process.env.MATOMO_URL,
             siteId: process.env.MATOMO_SITE_ID
-        }).head
+        })
     ]
 })

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,5 +1,6 @@
 import {defineConfig} from 'vitepress'
 import {getLatestVersionSync} from './version.js'
+import {createMatomoPlugin} from './plugins/vitepress-plugin-matomo.js'
 
 const version = getLatestVersionSync();
 
@@ -123,7 +124,7 @@ export default defineConfig({
     markdown: {
         lineNumbers: true,
         linkify: true,
-        config: (md) => {
+        config: () => {
             // Add any markdown-it plugins here if needed
         }
     },
@@ -147,6 +148,10 @@ export default defineConfig({
             content: 'Open-source, privacy-preserving framework for monitoring and ensuring data quality in biomedical research environments'
         }],
         ['meta', {name: 'twitter:card', content: 'summary_large_image'}],
-        ['meta', {name: 'twitter:image', content: '/logo.svg'}]
+        ['meta', {name: 'twitter:image', content: '/logo.svg'}],
+        ...createMatomoPlugin({
+            baseUrl: process.env.MATOMO_BASE_URL ?? process.env.MATOMO_URL,
+            siteId: process.env.MATOMO_SITE_ID
+        }).head
     ]
 })

--- a/docs/.vitepress/plugins/matomo.js
+++ b/docs/.vitepress/plugins/matomo.js
@@ -1,0 +1,2 @@
+export {createMatomoPlugin, matomoPlugin, normalizeMatomoBaseUrl} from './vitepress-plugin-matomo.js'
+

--- a/docs/.vitepress/plugins/vitepress-plugin-matomo.js
+++ b/docs/.vitepress/plugins/vitepress-plugin-matomo.js
@@ -6,57 +6,59 @@ function normalizeMatomoBaseUrl(baseUrl) {
     return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
 }
 
-export function createMatomoPlugin(options = {}) {
-    const baseUrl = normalizeMatomoBaseUrl(options.baseUrl ?? process.env.MATOMO_BASE_URL ?? process.env.MATOMO_URL)
-    const siteId = (options.siteId ?? process.env.MATOMO_SITE_ID ?? '').trim()
+function resolveMatomoSettings(options = {}) {
+    return {
+        baseUrl: normalizeMatomoBaseUrl(options.baseUrl ?? process.env.MATOMO_BASE_URL ?? process.env.MATOMO_URL),
+        siteId: (options.siteId ?? process.env.MATOMO_SITE_ID ?? '').trim()
+    }
+}
+
+function getMatomoRuntimeConfig() {
+    if (typeof window === 'undefined') {
+        return null
+    }
+
+    const config = window.__MATOMO_CONFIG__
+
+    if (!config?.baseUrl || !config?.siteId) {
+        return null
+    }
+
+    return config
+}
+
+export function hasMatomoRuntimeConfig() {
+    return getMatomoRuntimeConfig() !== null
+}
+
+export function createMatomoConfigEntries(options = {}) {
+    const {baseUrl, siteId} = resolveMatomoSettings(options)
 
     if (!baseUrl || !siteId) {
-        return {
-            head: [],
-            enhanceApp: () => {}
-        }
+        return []
     }
 
-    return {
-        head: [
-            ['script', {}, `
-var _paq = window._paq = window._paq || [];
-_paq.push(['trackPageView']);
-_paq.push(['enableLinkTracking']);
-(function() {
-  var u = ${JSON.stringify(baseUrl)};
-  _paq.push(['setTrackerUrl', u + 'matomo.php']);
-  _paq.push(['setSiteId', ${JSON.stringify(siteId)}]);
-  var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-  g.async = true;
-  g.src = u + 'matomo.js';
-  s.parentNode.insertBefore(g, s);
-})();
-            `]
-        ],
-        enhanceApp({router}) {
-            router.onAfterRouteChanged = (to) => {
-                if (typeof window === 'undefined' || !window._paq) {
-                    return
-                }
+    return [
+        ['script', {}, `window.__MATOMO_CONFIG__ = ${JSON.stringify({baseUrl, siteId})};`]
+    ]
+}
 
-                window._paq.push(['setCustomUrl', to])
-                window._paq.push(['setDocumentTitle', document.title])
-                window._paq.push(['trackPageView'])
-            }
-        }
+
+export function trackMatomoPageView(url) {
+    if (typeof window === 'undefined' || !window._paq) {
+        return
     }
+
+    window._paq.push(['setCustomUrl', url])
+    window._paq.push(['setDocumentTitle', document.title])
+    window._paq.push(['trackPageView'])
 }
 
 export function setupMatomoRouteTracking(router) {
     router.onAfterRouteChanged = (to) => {
-        if (typeof window === 'undefined' || !window._paq) {
-            return
-        }
-
-        window._paq.push(['setCustomUrl', to])
-        window._paq.push(['setDocumentTitle', document.title])
-        window._paq.push(['trackPageView'])
+        trackMatomoPageView(to)
     }
 }
+
+export {normalizeMatomoBaseUrl}
 

--- a/docs/.vitepress/plugins/vitepress-plugin-matomo.js
+++ b/docs/.vitepress/plugins/vitepress-plugin-matomo.js
@@ -1,0 +1,62 @@
+function normalizeMatomoBaseUrl(baseUrl) {
+    if (!baseUrl) {
+        return ''
+    }
+
+    return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+}
+
+export function createMatomoPlugin(options = {}) {
+    const baseUrl = normalizeMatomoBaseUrl(options.baseUrl ?? process.env.MATOMO_BASE_URL ?? process.env.MATOMO_URL)
+    const siteId = (options.siteId ?? process.env.MATOMO_SITE_ID ?? '').trim()
+
+    if (!baseUrl || !siteId) {
+        return {
+            head: [],
+            enhanceApp: () => {}
+        }
+    }
+
+    return {
+        head: [
+            ['script', {}, `
+var _paq = window._paq = window._paq || [];
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u = ${JSON.stringify(baseUrl)};
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', ${JSON.stringify(siteId)}]);
+  var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.src = u + 'matomo.js';
+  s.parentNode.insertBefore(g, s);
+})();
+            `]
+        ],
+        enhanceApp({router}) {
+            router.onAfterRouteChanged = (to) => {
+                if (typeof window === 'undefined' || !window._paq) {
+                    return
+                }
+
+                window._paq.push(['setCustomUrl', to])
+                window._paq.push(['setDocumentTitle', document.title])
+                window._paq.push(['trackPageView'])
+            }
+        }
+    }
+}
+
+export function setupMatomoRouteTracking(router) {
+    router.onAfterRouteChanged = (to) => {
+        if (typeof window === 'undefined' || !window._paq) {
+            return
+        }
+
+        window._paq.push(['setCustomUrl', to])
+        window._paq.push(['setDocumentTitle', document.title])
+        window._paq.push(['trackPageView'])
+    }
+}
+

--- a/docs/.vitepress/theme/CookieConsentBanner.vue
+++ b/docs/.vitepress/theme/CookieConsentBanner.vue
@@ -1,0 +1,200 @@
+<script setup>
+import {computed, onMounted, ref} from 'vue'
+import {hasMatomoRuntimeConfig} from '../plugins/vitepress-plugin-matomo.js'
+
+const MATOMO_CONSENT_STORAGE_KEY = 'fdqf-matomo-consent'
+const MATOMO_CONSENT_ACCEPTED = 'accepted'
+const MATOMO_SCRIPT_ID = 'fdqf-matomo-tracker'
+
+const consentState = ref('pending')
+const matomoEnabled = ref(false)
+const isVisible = computed(() => matomoEnabled.value && consentState.value === 'pending')
+
+function getConsentState() {
+  try {
+    return window.localStorage.getItem(MATOMO_CONSENT_STORAGE_KEY) ?? 'pending'
+  } catch {
+    return 'pending'
+  }
+}
+
+function setConsentState(value) {
+  try {
+    window.localStorage.setItem(MATOMO_CONSENT_STORAGE_KEY, value)
+  } catch {
+    // Ignore storage errors so the site still works without persistence.
+  }
+}
+
+function ensureMatomoQueue() {
+  window._paq = window._paq || []
+  return window._paq
+}
+
+function ensureMatomoScriptLoaded(baseUrl) {
+  if (document.getElementById(MATOMO_SCRIPT_ID)) {
+    return
+  }
+
+  const script = document.createElement('script')
+  script.id = MATOMO_SCRIPT_ID
+  script.async = true
+  script.src = `${baseUrl}matomo.js`
+
+  const firstScript = document.getElementsByTagName('script')[0]
+  if (firstScript?.parentNode) {
+    firstScript.parentNode.insertBefore(script, firstScript)
+  } else {
+    document.head.appendChild(script)
+  }
+}
+
+function loadMatomoTracker() {
+  const config = window.__MATOMO_CONFIG__
+
+  if (!config?.baseUrl || !config?.siteId) {
+    return false
+  }
+
+  const queue = ensureMatomoQueue()
+  queue.push(['setTrackerUrl', `${config.baseUrl}matomo.php`])
+  queue.push(['setSiteId', config.siteId])
+  queue.push(['enableLinkTracking'])
+  ensureMatomoScriptLoaded(config.baseUrl)
+  queue.push(['trackPageView'])
+  return true
+}
+
+function acceptAnalytics() {
+  setConsentState(MATOMO_CONSENT_ACCEPTED)
+  consentState.value = 'accepted'
+  loadMatomoTracker()
+}
+
+onMounted(() => {
+  matomoEnabled.value = hasMatomoRuntimeConfig()
+
+  if (!matomoEnabled.value) {
+    return
+  }
+
+  consentState.value = getConsentState()
+
+  if (consentState.value === 'accepted') {
+    loadMatomoTracker()
+  }
+})
+</script>
+
+<template>
+  <div v-if="isVisible" class="matomo-consent-banner" role="dialog" aria-describedby="matomo-consent-description">
+    <div class="matomo-consent-banner__inner">
+      <div class="matomo-consent-banner__content">
+        <p id="matomo-consent-description" class="matomo-consent-banner__text">
+          We use self-hosted Matomo analytics to understand how the docs are used.
+        </p>
+      </div>
+
+      <div class="matomo-consent-banner__actions">
+        <button class="VPButton medium alt matomo-consent-banner__button" type="button" @click="acceptAnalytics">
+          I understand
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.matomo-consent-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 60;
+  padding: 0.45rem;
+  pointer-events: none;
+}
+
+.matomo-consent-banner__inner {
+  max-width: 740px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--vp-c-bg) 96%, var(--vp-c-brand-soft));
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.08);
+  pointer-events: auto;
+}
+
+.matomo-consent-banner__content {
+  min-width: 0;
+}
+
+.matomo-consent-banner__text {
+  margin: 0;
+  color: var(--vp-c-text-2);
+  line-height: 1.4;
+  max-width: 52ch;
+  font-size: 0.88rem;
+}
+
+.matomo-consent-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: flex-end;
+  align-self: center;
+  min-width: 0;
+}
+
+.matomo-consent-banner__actions :deep(.VPButton) {
+  min-width: 124px;
+  border-radius: 999px;
+  font-size: 0.86rem;
+  padding-inline: 0.9rem;
+  transition:
+    color 0.18s ease,
+    background-color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.matomo-consent-banner__button:hover,
+.matomo-consent-banner__button:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.matomo-consent-banner__button:hover {
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 28%, var(--vp-c-divider));
+  color: var(--vp-c-brand-1);
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 24%, transparent);
+}
+
+.matomo-consent-banner__button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--vp-c-brand-1) 55%, white);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .matomo-consent-banner__inner {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0.65rem;
+  }
+
+  .matomo-consent-banner__actions {
+    justify-content: stretch;
+    min-width: 0;
+  }
+
+  .matomo-consent-banner__actions :deep(.VPButton) {
+    width: 100%;
+    justify-content: center;
+  }
+}
+</style>
+

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,13 +3,14 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import 'bootstrap-icons/font/bootstrap-icons.css'
+import CookieConsentBanner from './CookieConsentBanner.vue'
 import {setupMatomoRouteTracking} from '../plugins/vitepress-plugin-matomo.js'
 
 export default {
   extends: DefaultTheme,
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
-      // https://vitepress.dev/guide/extending-default-theme#layout-slots
+      'layout-bottom': () => h(CookieConsentBanner)
     })
   },
   enhanceApp({ router }) {

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,6 +3,7 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import 'bootstrap-icons/font/bootstrap-icons.css'
+import {setupMatomoRouteTracking} from '../plugins/vitepress-plugin-matomo.js'
 
 export default {
   extends: DefaultTheme,
@@ -11,7 +12,7 @@ export default {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
     })
   },
-  enhanceApp({ app, router, siteData }) {
-    // ...
+  enhanceApp({ router }) {
+    setupMatomoRouteTracking(router)
   }
 }


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces privacy-friendly Matomo analytics tracking to the documentation site, with user consent management and improved integration with the VitePress build system. The main changes add a Matomo plugin, a cookie consent banner, and route tracking, while ensuring analytics are only enabled after user acceptance.

**Matomo Analytics Integration:**

* Added a new plugin (`vitepress-plugin-matomo.js`) that provides functions for configuring, enabling, and tracking page views with Matomo, including helpers for environment variable configuration and runtime checks.
* Updated the VitePress config (`config.js`) to inject Matomo settings into the site’s HTML using environment variables, and to include the plugin for use throughout the docs site. [[1]](diffhunk://#diff-0a4e5303994d6be8e931143d050187fa18a698da42955821d63b7b70e5a451c9R3) [[2]](diffhunk://#diff-0a4e5303994d6be8e931143d050187fa18a698da42955821d63b7b70e5a451c9L150-R155) [[3]](diffhunk://#diff-0a4e5303994d6be8e931143d050187fa18a698da42955821d63b7b70e5a451c9L126-R127) [[4]](diffhunk://#diff-bf7c3368fbe3fc84a65498654c122d12a8c06f584fbafb84fc4d3318160ac14eR1-R2)
* Updated the CI workflow (`ci.yml`) to set the necessary environment variables (`MATOMO_BASE_URL`, `MATOMO_SITE_ID`) for documentation builds on the master branch.

**User Consent and Privacy:**

* Added a `CookieConsentBanner.vue` component that displays a banner requesting user consent before enabling Matomo analytics, and only loads the tracker once consent is given. Consent is stored in localStorage for future visits.
* Integrated the consent banner into the VitePress theme and enabled route tracking for analytics, ensuring page views are tracked only after consent.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
