### PR TITLE
feat: improve obfuscation processing

### DIFF
--- a/agent/backend/pom.xml
+++ b/agent/backend/pom.xml
@@ -227,6 +227,12 @@
                     <configuration>
                         <release>${java.version}</release>
                         <parameters>true</parameters>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtil.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtil.java
@@ -11,7 +11,7 @@ import java.security.SecureRandom;
 public class DifferentialPrivacyUtil {
 
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-  private static double LOW_COUNT_THRESHOLD = 10.0;
+  private static volatile double LOW_COUNT_THRESHOLD = 10.0;
 
   /**
    * Sets the low-count suppression threshold.
@@ -64,8 +64,8 @@ public class DifferentialPrivacyUtil {
    */
   public static double addGaussianNoise(
       int count, double epsilon, double delta, double sensitivity) {
-    if (epsilon <= 0) {
-      throw new IllegalArgumentException("Epsilon must be positive, got: " + epsilon);
+    if (epsilon <= 0 || epsilon > 1.0) {
+      throw new IllegalArgumentException("Epsilon must be in (0, 1], got: " + epsilon);
     }
     if (delta <= 0 || delta >= 1) {
       throw new IllegalArgumentException("Delta must be in (0, 1), got: " + delta);

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtil.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtil.java
@@ -11,7 +11,19 @@ import java.security.SecureRandom;
 public class DifferentialPrivacyUtil {
 
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-  private static final double LOW_COUNT_THRESHOLD = 10.0;
+  private static double LOW_COUNT_THRESHOLD = 10.0;
+
+  /**
+   * Sets the low-count suppression threshold.
+   *
+   * @param threshold the new threshold (must be non-negative)
+   */
+  public static synchronized void setLowCountThreshold(double threshold) {
+    if (threshold < 0) {
+      throw new IllegalArgumentException("Threshold must be non-negative, got: " + threshold);
+    }
+    LOW_COUNT_THRESHOLD = threshold;
+  }
 
   /**
    * Adds Laplace noise to a count, then suppresses if below threshold.

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtil.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtil.java
@@ -3,10 +3,10 @@ package eu.bbmri_eric.quality.agent.dataquality;
 import java.security.SecureRandom;
 
 /**
- * Applies differential privacy using the Laplace mechanism with low count suppression.
+ * Applies differential privacy using Laplace or Gaussian mechanisms with low count suppression.
  *
- * <p>Noise is always added to counts (scale λ = sensitivity/ε), then noisy counts below the
- * threshold are suppressed. This maintains ε-differential privacy while protecting low counts.
+ * <p>Noise is added to counts, then noisy counts below the threshold are suppressed. This maintains
+ * differential privacy while protecting low counts.
  */
 public class DifferentialPrivacyUtil {
 
@@ -50,6 +50,52 @@ public class DifferentialPrivacyUtil {
     }
 
     return noisyCount;
+  }
+
+  /**
+   * Adds Gaussian noise to a count for (ε, δ)-differential privacy, then suppresses if below
+   * threshold.
+   *
+   * @param count the original count
+   * @param epsilon the privacy budget (must be positive)
+   * @param delta the probability of privacy failure (must be positive and less than 1)
+   * @param sensitivity the query sensitivity (must be positive)
+   * @return noisy count clamped at 0, or 0 if below threshold
+   */
+  public static double addGaussianNoise(
+      int count, double epsilon, double delta, double sensitivity) {
+    if (epsilon <= 0) {
+      throw new IllegalArgumentException("Epsilon must be positive, got: " + epsilon);
+    }
+    if (delta <= 0 || delta >= 1) {
+      throw new IllegalArgumentException("Delta must be in (0, 1), got: " + delta);
+    }
+    if (sensitivity <= 0) {
+      throw new IllegalArgumentException("Sensitivity must be positive, got: " + sensitivity);
+    }
+
+    double standardDeviation = sensitivity * Math.sqrt(2.0 * Math.log(1.25 / delta)) / epsilon;
+    double noise = SECURE_RANDOM.nextGaussian() * standardDeviation;
+    double noisyCount = Math.max(0.0, count + noise);
+
+    if (noisyCount < LOW_COUNT_THRESHOLD) {
+      return 0.0;
+    }
+
+    return noisyCount;
+  }
+
+  /**
+   * Returns the standard deviation used by the Gaussian mechanism for the given parameters.
+   *
+   * @param epsilon the privacy budget
+   * @param delta the probability of privacy failure
+   * @param sensitivity the query sensitivity
+   * @return σ = sensitivity * sqrt(2 * ln(1.25/δ)) / ε
+   */
+  public static double calculateGaussianStandardDeviation(
+      double epsilon, double delta, double sensitivity) {
+    return sensitivity * Math.sqrt(2.0 * Math.log(1.25 / delta)) / epsilon;
   }
 
   /**

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/config/ResultMapper.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/config/ResultMapper.java
@@ -5,7 +5,6 @@ import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ResultDTO;
 import jakarta.annotation.PostConstruct;
 import org.modelmapper.ModelMapper;
-import org.modelmapper.PropertyMap;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -19,14 +18,17 @@ public class ResultMapper {
 
   @PostConstruct
   public void addMappings() {
-    modelMapper.addMappings(
-        new PropertyMap<ResultDTO, Result>() {
-          @Override
-          protected void configure() {
-            map().setRawValue(source.rawResult());
-            map().setPatients(source.idSet());
-          }
-        });
+    modelMapper
+        .typeMap(ResultDTO.class, Result.class)
+        .setPostConverter(
+            context -> {
+              ResultDTO source = context.getSource();
+              Result destination = context.getDestination();
+              destination.setRawValue(source.rawResult());
+              destination.setPatients(source.idSet());
+              return destination;
+            });
+
     modelMapper
         .getConfiguration()
         .setPropertyCondition(

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/DataQualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/DataQualityCheck.java
@@ -53,7 +53,7 @@ public interface DataQualityCheck {
    *
    * @return the epsilon budget
    */
-  Float getEpsilonBudget();
+  Double getEpsilonBudget();
 
   /**
    * Returns the unique identifier of this data quality check, if applicable.

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/DataQualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/DataQualityCheck.java
@@ -53,7 +53,7 @@ public interface DataQualityCheck {
    *
    * @return the epsilon budget
    */
-  float getEpsilonBudget();
+  Float getEpsilonBudget();
 
   /**
    * Returns the unique identifier of this data quality check, if applicable.

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
@@ -35,7 +35,7 @@ public class QualityCheck implements DataQualityCheck {
 
   private int warningThreshold = 10;
   private int errorThreshold = 30;
-  private Float epsilonBudget = 1.0f;
+  private Float epsilonBudget;
 
   protected QualityCheck() {}
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
@@ -35,7 +35,7 @@ public class QualityCheck implements DataQualityCheck {
 
   private int warningThreshold = 10;
   private int errorThreshold = 30;
-  private Float epsilonBudget;
+  private Double epsilonBudget;
 
   protected QualityCheck() {}
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
@@ -35,7 +35,7 @@ public class QualityCheck implements DataQualityCheck {
 
   private int warningThreshold = 10;
   private int errorThreshold = 30;
-  private float epsilonBudget = 1.0f;
+  private Float epsilonBudget = 1.0f;
 
   protected QualityCheck() {}
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
@@ -36,6 +36,7 @@ public class QualityCheck implements DataQualityCheck {
 
   private int warningThreshold = 10;
   private int errorThreshold = 30;
+
   @Getter(AccessLevel.NONE)
   private Double epsilonBudget;
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/QualityCheck.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -35,7 +36,13 @@ public class QualityCheck implements DataQualityCheck {
 
   private int warningThreshold = 10;
   private int errorThreshold = 30;
+  @Getter(AccessLevel.NONE)
   private Double epsilonBudget;
+
+  @Override
+  public Double getEpsilonBudget() {
+    return epsilonBudget;
+  }
 
   protected QualityCheck() {}
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Report.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Report.java
@@ -39,7 +39,7 @@ public class Report {
   @Enumerated(EnumType.STRING)
   private ReportStatus status = ReportStatus.GENERATING;
 
-  private float epsilonBudget = 2.0f;
+  private double epsilonBudget = 2.0;
 
   private Integer numberOfEntities;
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Result.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Result.java
@@ -37,7 +37,7 @@ public class Result {
   private Double obfuscatedValue;
   private int warningThreshold;
   private int errorThreshold;
-  private Float epsilon;
+  private Double epsilon;
   private String error;
   private String stratum;
 
@@ -55,7 +55,7 @@ public class Result {
       Double obfuscatedValue,
       int warningThreshold,
       int errorThreshold,
-      Float epsilon,
+      Double epsilon,
       String error,
       String stratum) {
     this.checkName = checkName;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Result.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Result.java
@@ -37,7 +37,7 @@ public class Result {
   private Double obfuscatedValue;
   private int warningThreshold;
   private int errorThreshold;
-  private float epsilon;
+  private Float epsilon;
   private String error;
   private String stratum;
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Result.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/domain/Result.java
@@ -55,7 +55,7 @@ public class Result {
       Double obfuscatedValue,
       int warningThreshold,
       int errorThreshold,
-      float epsilon,
+      Float epsilon,
       String error,
       String stratum) {
     this.checkName = checkName;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckCreateDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckCreateDTO.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -43,8 +42,6 @@ public class QualityCheckCreateDTO {
   @Schema(description = "Error threshold percentage", example = "30")
   private Integer errorThreshold;
 
-  @NotNull(message = "Epsilon budget is required")
-  @Positive(message = "Epsilon budget must be positive")
   @Schema(description = "Epsilon budget for differential privacy", example = "1.0")
   private Float epsilonBudget;
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckCreateDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckCreateDTO.java
@@ -43,7 +43,7 @@ public class QualityCheckCreateDTO {
   private Integer errorThreshold;
 
   @Schema(description = "Epsilon budget for differential privacy", example = "1.0")
-  private Float epsilonBudget;
+  private Double epsilonBudget;
 
   public QualityCheckCreateDTO() {}
 
@@ -53,7 +53,7 @@ public class QualityCheckCreateDTO {
       String query,
       Integer warningThreshold,
       Integer errorThreshold,
-      Float epsilonBudget) {
+      Double epsilonBudget) {
     this.name = name;
     this.description = description;
     this.query = query;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckDTO.java
@@ -37,7 +37,7 @@ public class QualityCheckDTO {
   private int errorThreshold;
 
   @Schema(description = "Epsilon budget for differential privacy", example = "1.0")
-  private float epsilonBudget;
+  private Float epsilonBudget;
 
   public QualityCheckDTO() {}
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckDTO.java
@@ -37,7 +37,7 @@ public class QualityCheckDTO {
   private int errorThreshold;
 
   @Schema(description = "Epsilon budget for differential privacy", example = "1.0")
-  private Float epsilonBudget;
+  private Double epsilonBudget;
 
   public QualityCheckDTO() {}
 
@@ -49,7 +49,7 @@ public class QualityCheckDTO {
       QualityCheckType type,
       int warningThreshold,
       int errorThreshold,
-      float epsilonBudget) {
+      double epsilonBudget) {
     this.id = id;
     this.name = name;
     this.description = description;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckUpdateDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/QualityCheckUpdateDTO.java
@@ -39,7 +39,7 @@ public class QualityCheckUpdateDTO {
 
   @Positive(message = "Epsilon budget must be positive")
   @Schema(description = "Epsilon budget for differential privacy", example = "1.0")
-  private Float epsilonBudget;
+  private Double epsilonBudget;
 
   public QualityCheckUpdateDTO() {}
 
@@ -49,7 +49,7 @@ public class QualityCheckUpdateDTO {
       String query,
       Integer warningThreshold,
       Integer errorThreshold,
-      Float epsilonBudget) {
+      Double epsilonBudget) {
     this.name = name;
     this.description = description;
     this.query = query;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportDTO.java
@@ -12,7 +12,7 @@ public class ReportDTO {
   private Long id;
   private LocalDateTime generatedAt;
   private ReportStatus status;
-  private float epsilonBudget;
+  private double epsilonBudget;
   private Integer numberOfEntities;
   private Integer numberOfSecondaryEntities;
   private List<ReportResultDTO> results;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportResultDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportResultDTO.java
@@ -12,7 +12,7 @@ public class ReportResultDTO {
   private Double obfuscatedValue;
   private int warningThreshold;
   private int errorThreshold;
-  private float epsilon;
+  private double epsilon;
   private String error;
   private String stratum;
   private Set<String> patients;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/event/DataQualityCheckResultEvent.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/event/DataQualityCheckResultEvent.java
@@ -15,7 +15,7 @@ public class DataQualityCheckResultEvent {
   private final LocalDateTime finishedAt;
   private final int warningThreshold;
   private final int errorThreshold;
-  private final float epsilon;
+  private final double epsilon;
   private final String stratum;
 
   public DataQualityCheckResultEvent(
@@ -27,7 +27,7 @@ public class DataQualityCheckResultEvent {
       LocalDateTime finishedAt,
       int warningThreshold,
       int errorThreshold,
-      float epsilon,
+      double epsilon,
       String stratum) {
     this.checkId = checkId;
     this.checkName = checkName;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/DuplicateIdentifierCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/DuplicateIdentifierCheck.java
@@ -93,7 +93,7 @@ class DuplicateIdentifierCheck implements DataQualityCheck {
   }
 
   @Override
-  public Float getEpsilonBudget() {
+  public Double getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/DuplicateIdentifierCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/DuplicateIdentifierCheck.java
@@ -93,7 +93,7 @@ class DuplicateIdentifierCheck implements DataQualityCheck {
   }
 
   @Override
-  public float getEpsilonBudget() {
+  public Float getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/InvalidConditionICDCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/InvalidConditionICDCheck.java
@@ -95,7 +95,7 @@ class InvalidConditionICDCheck implements DataQualityCheck {
   }
 
   @Override
-  public float getEpsilonBudget() {
+  public Float getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/InvalidConditionICDCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/InvalidConditionICDCheck.java
@@ -95,7 +95,7 @@ class InvalidConditionICDCheck implements DataQualityCheck {
   }
 
   @Override
-  public Float getEpsilonBudget() {
+  public Double getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -25,25 +25,37 @@ class ObfuscationStep implements ReportPipelineStep {
     this.qualityCheckService = qualityCheckService;
   }
 
-  private static List<Result> resultsWithNonNullValues(List<Result> results) {
+  @Override
+  public Report execute(Report report) {
+    obfuscateResults(report);
+    log.info("Completed obfuscation for report id: {}", report.getId());
+    return report;
+  }
+
+  @Override
+  public int getOrder() {
+    return 20;
+  }
+
+  private List<Result> resultsWithNonNullValues(List<Result> results) {
     return results.stream().filter(r -> r.getRawValue() != null).toList();
   }
 
-  private static double computeTotalPreferredEpsilon(
+  private double computeTotalPreferredEpsilon(
       List<Result> results, Map<Long, Double> preferredBudgetByCheckId) {
     return results.stream()
         .mapToDouble(r -> preferredBudgetByCheckId.getOrDefault(r.getCheckId(), 0.0))
         .sum();
   }
 
-  private static long countResultsWithoutPreference(
+  private long countResultsWithoutPreference(
       List<Result> results, Map<Long, Double> preferredBudgetByCheckId) {
     return results.stream()
         .filter(r -> !preferredBudgetByCheckId.containsKey(r.getCheckId()))
         .count();
   }
 
-  private static double computeBaseEpsilon(
+  private double computeBaseEpsilon(
       double totalEpsilon,
       double totalPreferredEpsilon,
       int resultCount,
@@ -53,7 +65,7 @@ class ObfuscationStep implements ReportPipelineStep {
     return noPreferenceCount > 0 ? (totalEpsilon - totalPreferredEpsilon) / noPreferenceCount : 0;
   }
 
-  private static double resolveEpsilon(
+  private double resolveEpsilon(
       Result result,
       Map<Long, Double> preferredBudgetByCheckId,
       double baseEpsilon,
@@ -62,28 +74,19 @@ class ObfuscationStep implements ReportPipelineStep {
     return preferredBudgetByCheckId.getOrDefault(result.getCheckId(), baseEpsilon);
   }
 
-  private static void applyNoise(Result result, double epsilon) {
+  private void applyNoise(Result result, double epsilon) {
     double noisyValue = DifferentialPrivacyUtil.addLaplaceNoise(result.getRawValue(), epsilon, 1);
     result.setObfuscatedValue(noisyValue);
     result.setEpsilon(epsilon);
   }
 
-  @Override
-  public Report execute(Report report) {
-    log.info("Adding obfuscated values for report id: {}", report.getId());
-    obfuscateResults(report);
-    log.info("Completed obfuscation for report id: {}", report.getId());
-    return report;
-  }
-
   private void obfuscateResults(Report report) {
+    log.info("Adding obfuscated values for report id: {}", report.getId());
     List<Result> results = report.getResults();
     double totalEpsilon = settingsService.getSettings().getEpsilon();
     Map<Long, Double> preferredBudgetByCheckId = getPreferredBudgetByCheckId();
     List<Result> resultsToObfuscate = resultsWithNonNullValues(results);
-
     if (resultsToObfuscate.isEmpty()) return;
-
     double totalPreferredEpsilon =
         computeTotalPreferredEpsilon(resultsToObfuscate, preferredBudgetByCheckId);
     boolean ignorePreferences = totalPreferredEpsilon > totalEpsilon;
@@ -131,10 +134,5 @@ class ObfuscationStep implements ReportPipelineStep {
         totalResults,
         noPreferenceCount);
     log.debug("Using {} epsilon allocation", ignorePreferences ? "equal" : "preference-aware");
-  }
-
-  @Override
-  public int getOrder() {
-    return 20;
   }
 }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -4,20 +4,29 @@ import eu.bbmri_eric.quality.agent.dataquality.DifferentialPrivacyUtil;
 import eu.bbmri_eric.quality.agent.dataquality.ReportPipelineStep;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
+import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 class ObfuscationStep implements ReportPipelineStep {
+  private final SettingsService settingsService;
+
+  ObfuscationStep(SettingsService settingsService) {
+    this.settingsService = settingsService;
+  }
 
   @Override
   public Report execute(Report report) {
+    var reportEpsilonBudget = settingsService.getSettings().getEpsilon();
+    var numberOfResults = report.getResults().size();
     log.info("Adding obfuscated values for report id: {}", report.getId());
     for (Result result : report.getResults()) {
       if (result.getRawValue() != null) {
         double noisyValue =
-            DifferentialPrivacyUtil.addLaplaceNoise(result.getRawValue(), result.getEpsilon(), 1);
+            DifferentialPrivacyUtil.addLaplaceNoise(
+                result.getRawValue(), reportEpsilonBudget / numberOfResults, 1);
         result.setObfuscatedValue(noisyValue);
       }
     }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -1,10 +1,15 @@
 package eu.bbmri_eric.quality.agent.dataquality.impl;
 
 import eu.bbmri_eric.quality.agent.dataquality.DifferentialPrivacyUtil;
+import eu.bbmri_eric.quality.agent.dataquality.QualityCheckService;
 import eu.bbmri_eric.quality.agent.dataquality.ReportPipelineStep;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
+import eu.bbmri_eric.quality.agent.dataquality.dto.QualityCheckDTO;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -13,27 +18,116 @@ import org.springframework.stereotype.Component;
 @Component
 class ObfuscationStep implements ReportPipelineStep {
   private final SettingsService settingsService;
+  private final QualityCheckService qualityCheckService;
 
-  ObfuscationStep(SettingsService settingsService) {
+  ObfuscationStep(SettingsService settingsService, QualityCheckService qualityCheckService) {
     this.settingsService = settingsService;
+    this.qualityCheckService = qualityCheckService;
+  }
+
+  private static List<Result> resultsWithNonNullValues(List<Result> results) {
+    return results.stream().filter(r -> r.getRawValue() != null).toList();
+  }
+
+  private static double computeTotalPreferredEpsilon(
+      List<Result> results, Map<Long, Float> preferredBudgetByCheckId) {
+    return results.stream()
+        .mapToDouble(r -> preferredBudgetByCheckId.getOrDefault(r.getCheckId(), 0.0f))
+        .sum();
+  }
+
+  private static long countResultsWithoutPreference(
+      List<Result> results, Map<Long, Float> preferredBudgetByCheckId) {
+    return results.stream()
+        .filter(r -> !preferredBudgetByCheckId.containsKey(r.getCheckId()))
+        .count();
+  }
+
+  private static double computeBaseEpsilon(
+      double totalEpsilon,
+      double totalPreferredEpsilon,
+      int resultCount,
+      long noPreferenceCount,
+      boolean ignorePreferences) {
+    if (ignorePreferences) return totalEpsilon / resultCount;
+    return noPreferenceCount > 0
+        ? (totalEpsilon - totalPreferredEpsilon) / noPreferenceCount
+        : 0;
+  }
+
+  private static double resolveEpsilon(
+      Result result,
+      Map<Long, Float> preferredBudgetByCheckId,
+      double baseEpsilon,
+      boolean ignorePreferences) {
+    if (ignorePreferences) return baseEpsilon;
+    return preferredBudgetByCheckId.getOrDefault(result.getCheckId(), (float) baseEpsilon);
+  }
+
+  private static void applyNoise(Result result, double epsilon) {
+    double noisyValue =
+        DifferentialPrivacyUtil.addLaplaceNoise(result.getRawValue(), epsilon, 1);
+    result.setObfuscatedValue(noisyValue);
+    result.setEpsilon((float) epsilon);
   }
 
   @Override
   public Report execute(Report report) {
-    var reportEpsilonBudget = settingsService.getSettings().getEpsilon();
-    var numberOfResults = report.getResults().size();
     log.info("Adding obfuscated values for report id: {}", report.getId());
-    for (Result result : report.getResults()) {
-      if (result.getRawValue() != null) {
-        double noisyValue =
-            DifferentialPrivacyUtil.addLaplaceNoise(
-                result.getRawValue(), reportEpsilonBudget / numberOfResults, 1);
-        result.setObfuscatedValue(noisyValue);
-        result.setEpsilon((float) (reportEpsilonBudget / numberOfResults));
-      }
-    }
+    obfuscateResults(report);
     log.info("Completed obfuscation for report id: {}", report.getId());
     return report;
+  }
+
+  private void obfuscateResults(Report report) {
+    List<Result> results = report.getResults();
+    double totalEpsilon = settingsService.getSettings().getEpsilon();
+    Map<Long, Float> preferredBudgetByCheckId = getPreferredBudgetByCheckId();
+    List<Result> resultsToObfuscate = resultsWithNonNullValues(results);
+
+    if (resultsToObfuscate.isEmpty()) return;
+
+    double totalPreferredEpsilon =
+        computeTotalPreferredEpsilon(resultsToObfuscate, preferredBudgetByCheckId);
+    boolean ignorePreferences = totalPreferredEpsilon > totalEpsilon;
+    log.warn(String.valueOf(totalPreferredEpsilon));
+    log.warn(String.valueOf(totalEpsilon));
+    long noPreferenceCount =
+        countResultsWithoutPreference(resultsToObfuscate, preferredBudgetByCheckId);
+    double baseEpsilon =
+        computeBaseEpsilon(
+            totalEpsilon,
+            totalPreferredEpsilon,
+            resultsToObfuscate.size(),
+            noPreferenceCount,
+            ignorePreferences);
+    logAllocation(
+        totalEpsilon, totalPreferredEpsilon, resultsToObfuscate.size(), noPreferenceCount,
+        ignorePreferences);
+    for (Result result : results) {
+      if (result.getRawValue() == null) continue;
+      double epsilon =
+          resolveEpsilon(result, preferredBudgetByCheckId, baseEpsilon, ignorePreferences);
+      applyNoise(result, epsilon);
+    }
+  }
+
+  private Map<Long, Float> getPreferredBudgetByCheckId() {
+    return qualityCheckService.findAll().stream()
+        .filter(qc -> qc.getEpsilonBudget() != null)
+        .collect(Collectors.toMap(QualityCheckDTO::getId, QualityCheckDTO::getEpsilonBudget));
+  }
+
+  private void logAllocation(
+      double totalEpsilon,
+      double totalPreferredEpsilon,
+      int totalResults,
+      long noPreferenceCount,
+      boolean ignorePreferences) {
+    log.debug(
+        "Epsilon budget: total={}, preferredTotal={}, totalResults={}, noPreferenceCount={}",
+        totalEpsilon, totalPreferredEpsilon, totalResults, noPreferenceCount);
+    log.debug("Using {} epsilon allocation", ignorePreferences ? "equal" : "preference-aware");
   }
 
   @Override

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -30,14 +30,14 @@ class ObfuscationStep implements ReportPipelineStep {
   }
 
   private static double computeTotalPreferredEpsilon(
-      List<Result> results, Map<Long, Float> preferredBudgetByCheckId) {
+      List<Result> results, Map<Long, Double> preferredBudgetByCheckId) {
     return results.stream()
-        .mapToDouble(r -> preferredBudgetByCheckId.getOrDefault(r.getCheckId(), 0.0f))
+        .mapToDouble(r -> preferredBudgetByCheckId.getOrDefault(r.getCheckId(), 0.0))
         .sum();
   }
 
   private static long countResultsWithoutPreference(
-      List<Result> results, Map<Long, Float> preferredBudgetByCheckId) {
+      List<Result> results, Map<Long, Double> preferredBudgetByCheckId) {
     return results.stream()
         .filter(r -> !preferredBudgetByCheckId.containsKey(r.getCheckId()))
         .count();
@@ -50,25 +50,22 @@ class ObfuscationStep implements ReportPipelineStep {
       long noPreferenceCount,
       boolean ignorePreferences) {
     if (ignorePreferences) return totalEpsilon / resultCount;
-    return noPreferenceCount > 0
-        ? (totalEpsilon - totalPreferredEpsilon) / noPreferenceCount
-        : 0;
+    return noPreferenceCount > 0 ? (totalEpsilon - totalPreferredEpsilon) / noPreferenceCount : 0;
   }
 
   private static double resolveEpsilon(
       Result result,
-      Map<Long, Float> preferredBudgetByCheckId,
+      Map<Long, Double> preferredBudgetByCheckId,
       double baseEpsilon,
       boolean ignorePreferences) {
     if (ignorePreferences) return baseEpsilon;
-    return preferredBudgetByCheckId.getOrDefault(result.getCheckId(), (float) baseEpsilon);
+    return preferredBudgetByCheckId.getOrDefault(result.getCheckId(), baseEpsilon);
   }
 
   private static void applyNoise(Result result, double epsilon) {
-    double noisyValue =
-        DifferentialPrivacyUtil.addLaplaceNoise(result.getRawValue(), epsilon, 1);
+    double noisyValue = DifferentialPrivacyUtil.addLaplaceNoise(result.getRawValue(), epsilon, 1);
     result.setObfuscatedValue(noisyValue);
-    result.setEpsilon((float) epsilon);
+    result.setEpsilon(epsilon);
   }
 
   @Override
@@ -82,7 +79,7 @@ class ObfuscationStep implements ReportPipelineStep {
   private void obfuscateResults(Report report) {
     List<Result> results = report.getResults();
     double totalEpsilon = settingsService.getSettings().getEpsilon();
-    Map<Long, Float> preferredBudgetByCheckId = getPreferredBudgetByCheckId();
+    Map<Long, Double> preferredBudgetByCheckId = getPreferredBudgetByCheckId();
     List<Result> resultsToObfuscate = resultsWithNonNullValues(results);
 
     if (resultsToObfuscate.isEmpty()) return;
@@ -102,7 +99,10 @@ class ObfuscationStep implements ReportPipelineStep {
             noPreferenceCount,
             ignorePreferences);
     logAllocation(
-        totalEpsilon, totalPreferredEpsilon, resultsToObfuscate.size(), noPreferenceCount,
+        totalEpsilon,
+        totalPreferredEpsilon,
+        resultsToObfuscate.size(),
+        noPreferenceCount,
         ignorePreferences);
     for (Result result : results) {
       if (result.getRawValue() == null) continue;
@@ -112,7 +112,7 @@ class ObfuscationStep implements ReportPipelineStep {
     }
   }
 
-  private Map<Long, Float> getPreferredBudgetByCheckId() {
+  private Map<Long, Double> getPreferredBudgetByCheckId() {
     return qualityCheckService.findAll().stream()
         .filter(qc -> qc.getEpsilonBudget() != null)
         .collect(Collectors.toMap(QualityCheckDTO::getId, QualityCheckDTO::getEpsilonBudget));
@@ -126,7 +126,10 @@ class ObfuscationStep implements ReportPipelineStep {
       boolean ignorePreferences) {
     log.debug(
         "Epsilon budget: total={}, preferredTotal={}, totalResults={}, noPreferenceCount={}",
-        totalEpsilon, totalPreferredEpsilon, totalResults, noPreferenceCount);
+        totalEpsilon,
+        totalPreferredEpsilon,
+        totalResults,
+        noPreferenceCount);
     log.debug("Using {} epsilon allocation", ignorePreferences ? "equal" : "preference-aware");
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -84,6 +84,8 @@ class ObfuscationStep implements ReportPipelineStep {
     log.info("Adding obfuscated values for report id: {}", report.getId());
     List<Result> results = report.getResults();
     double totalEpsilon = settingsService.getSettings().getEpsilon();
+    int threshold = settingsService.getSettings().getMinThreshold();
+    DifferentialPrivacyUtil.setLowCountThreshold(threshold);
     Map<Long, Double> preferredBudgetByCheckId = getPreferredBudgetByCheckId();
     List<Result> resultsToObfuscate = resultsWithNonNullValues(results);
     if (resultsToObfuscate.isEmpty()) return;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -6,6 +6,7 @@ import eu.bbmri_eric.quality.agent.dataquality.ReportPipelineStep;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
 import eu.bbmri_eric.quality.agent.dataquality.dto.QualityCheckDTO;
+import eu.bbmri_eric.quality.agent.settings.NoiseMechanism;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import java.util.List;
 import java.util.Map;
@@ -74,8 +75,15 @@ class ObfuscationStep implements ReportPipelineStep {
     return preferredBudgetByCheckId.getOrDefault(result.getCheckId(), baseEpsilon);
   }
 
-  private void applyNoise(Result result, double epsilon) {
-    double noisyValue = DifferentialPrivacyUtil.addLaplaceNoise(result.getRawValue(), epsilon, 1);
+  private void applyNoise(
+      Result result, double epsilon, NoiseMechanism noiseMechanism, double delta) {
+    double noisyValue;
+    if (noiseMechanism == NoiseMechanism.GAUSSIAN) {
+      noisyValue =
+          DifferentialPrivacyUtil.addGaussianNoise(result.getRawValue(), epsilon, delta, 1);
+    } else {
+      noisyValue = DifferentialPrivacyUtil.addLaplaceNoise(result.getRawValue(), epsilon, 1);
+    }
     result.setObfuscatedValue(noisyValue);
     result.setEpsilon(epsilon);
   }
@@ -83,8 +91,11 @@ class ObfuscationStep implements ReportPipelineStep {
   private void obfuscateResults(Report report) {
     log.info("Adding obfuscated values for report id: {}", report.getId());
     List<Result> results = report.getResults();
-    double totalEpsilon = settingsService.getSettings().getEpsilon();
-    int threshold = settingsService.getSettings().getMinThreshold();
+    var settings = settingsService.getSettings();
+    double totalEpsilon = settings.getEpsilon();
+    double delta = settings.getDelta();
+    NoiseMechanism noiseMechanism = settings.getNoiseMechanism();
+    int threshold = settings.getMinThreshold();
     DifferentialPrivacyUtil.setLowCountThreshold(threshold);
     Map<Long, Double> preferredBudgetByCheckId = getPreferredBudgetByCheckId();
     List<Result> resultsToObfuscate = resultsWithNonNullValues(results);
@@ -113,7 +124,7 @@ class ObfuscationStep implements ReportPipelineStep {
       if (result.getRawValue() == null) continue;
       double epsilon =
           resolveEpsilon(result, preferredBudgetByCheckId, baseEpsilon, ignorePreferences);
-      applyNoise(result, epsilon);
+      applyNoise(result, epsilon, noiseMechanism, delta);
     }
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -8,6 +8,7 @@ import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+/** This pipeline step takes care of adding noise to individual report results. */
 @Slf4j
 @Component
 class ObfuscationStep implements ReportPipelineStep {
@@ -28,6 +29,7 @@ class ObfuscationStep implements ReportPipelineStep {
             DifferentialPrivacyUtil.addLaplaceNoise(
                 result.getRawValue(), reportEpsilonBudget / numberOfResults, 1);
         result.setObfuscatedValue(noisyValue);
+        result.setEpsilon((float) (reportEpsilonBudget / numberOfResults));
       }
     }
     log.info("Completed obfuscation for report id: {}", report.getId());

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStep.java
@@ -103,8 +103,6 @@ class ObfuscationStep implements ReportPipelineStep {
     double totalPreferredEpsilon =
         computeTotalPreferredEpsilon(resultsToObfuscate, preferredBudgetByCheckId);
     boolean ignorePreferences = totalPreferredEpsilon > totalEpsilon;
-    log.warn(String.valueOf(totalPreferredEpsilon));
-    log.warn(String.valueOf(totalEpsilon));
     long noPreferenceCount =
         countResultsWithoutPreference(resultsToObfuscate, preferredBudgetByCheckId);
     double baseEpsilon =

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/QualityChecksStep.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/QualityChecksStep.java
@@ -107,7 +107,6 @@ class QualityChecksStep implements ReportPipelineStep {
       modelMapper.map(check, result);
       result.setStratum(check.getName() + " (%s)".formatted(stratum));
       result.setCheckName(check.getName() + " (%s)".formatted(stratum));
-      result.setEpsilon(check.getEpsilonBudget() / count);
       report.addResult(result);
     }
   }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/StratifiedDataQualityCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/StratifiedDataQualityCheck.java
@@ -5,6 +5,7 @@ import eu.bbmri_eric.quality.agent.dataquality.domain.DataQualityCheck;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ResultDTO;
 import java.util.Map;
 
+// TODO: remove all support for this
 interface StratifiedDataQualityCheck extends DataQualityCheck {
   Map<String, ResultDTO> executeWithStratification(FHIRServer fhirStore);
 }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/SurvivalRateCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/SurvivalRateCheck.java
@@ -114,7 +114,7 @@ class SurvivalRateCheck implements StratifiedDataQualityCheck {
   }
 
   @Override
-  public Float getEpsilonBudget() {
+  public Double getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/SurvivalRateCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/SurvivalRateCheck.java
@@ -114,7 +114,7 @@ class SurvivalRateCheck implements StratifiedDataQualityCheck {
   }
 
   @Override
-  public float getEpsilonBudget() {
+  public Float getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/UpdateCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/UpdateCheck.java
@@ -85,7 +85,7 @@ class UpdateCheck implements DataQualityCheck {
   }
 
   @Override
-  public float getEpsilonBudget() {
+  public Float getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/UpdateCheck.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/UpdateCheck.java
@@ -85,7 +85,7 @@ class UpdateCheck implements DataQualityCheck {
   }
 
   @Override
-  public Float getEpsilonBudget() {
+  public Double getEpsilonBudget() {
     return config.getEpsilonBudget();
   }
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/dto/SettingsDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/dto/SettingsDTO.java
@@ -51,23 +51,18 @@ public class SettingsDTO {
       requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   private String fhirPassword;
 
-  @NotNull(message = "Epsilon is required")
   @Positive(message = "Epsilon must be positive")
   @Schema(
       description = "Privacy budget (ε)",
-      example = "3.0",
-      requiredMode = Schema.RequiredMode.REQUIRED)
+      example = "3.0")
   private Double epsilon;
 
-  @NotNull(message = "Delta is required")
   @Positive(message = "Delta must be positive")
   @Schema(
       description = "Delta parameter (δ) - probability of privacy failure",
-      example = "1e-8",
-      requiredMode = Schema.RequiredMode.REQUIRED)
+      example = "1e-8")
   private Double delta;
 
-  @NotNull(message = "Minimum threshold is required")
   @Min(value = 0, message = "Minimum threshold must be non-negative")
   @Schema(
       description = "Minimum threshold for low count suppression",
@@ -75,18 +70,14 @@ public class SettingsDTO {
       requiredMode = Schema.RequiredMode.REQUIRED)
   private Integer minThreshold;
 
-  @NotNull(message = "Noise mechanism is required")
   @Schema(
       description = "Noise mechanism (LAPLACE or GAUSSIAN)",
-      example = "LAPLACE",
-      requiredMode = Schema.RequiredMode.REQUIRED)
+      example = "LAPLACE")
   private NoiseMechanism noiseMechanism;
 
-  @NotNull(message = "Database type is required")
   @Schema(
       description = "Database type (FHIR or SQL)",
-      example = "FHIR",
-      requiredMode = Schema.RequiredMode.REQUIRED)
+      example = "FHIR")
   private DatabaseType databaseType;
 
   @Size(max = 500, message = "SQL URL must not exceed 500 characters")

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/dto/SettingsDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/dto/SettingsDTO.java
@@ -4,7 +4,6 @@ import eu.bbmri_eric.quality.agent.settings.DatabaseType;
 import eu.bbmri_eric.quality.agent.settings.NoiseMechanism;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -52,15 +51,11 @@ public class SettingsDTO {
   private String fhirPassword;
 
   @Positive(message = "Epsilon must be positive")
-  @Schema(
-      description = "Privacy budget (ε)",
-      example = "3.0")
+  @Schema(description = "Privacy budget (ε)", example = "3.0")
   private Double epsilon;
 
   @Positive(message = "Delta must be positive")
-  @Schema(
-      description = "Delta parameter (δ) - probability of privacy failure",
-      example = "1e-8")
+  @Schema(description = "Delta parameter (δ) - probability of privacy failure", example = "1e-8")
   private Double delta;
 
   @Min(value = 0, message = "Minimum threshold must be non-negative")
@@ -70,14 +65,10 @@ public class SettingsDTO {
       requiredMode = Schema.RequiredMode.REQUIRED)
   private Integer minThreshold;
 
-  @Schema(
-      description = "Noise mechanism (LAPLACE or GAUSSIAN)",
-      example = "LAPLACE")
+  @Schema(description = "Noise mechanism (LAPLACE or GAUSSIAN)", example = "LAPLACE")
   private NoiseMechanism noiseMechanism;
 
-  @Schema(
-      description = "Database type (FHIR or SQL)",
-      example = "FHIR")
+  @Schema(description = "Database type (FHIR or SQL)", example = "FHIR")
   private DatabaseType databaseType;
 
   @Size(max = 500, message = "SQL URL must not exceed 500 characters")

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/impl/SettingsServiceImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/impl/SettingsServiceImpl.java
@@ -3,6 +3,7 @@ package eu.bbmri_eric.quality.agent.settings.impl;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.bbmri_eric.quality.agent.common.EventPublisher;
+import eu.bbmri_eric.quality.agent.settings.NoiseMechanism;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import eu.bbmri_eric.quality.agent.settings.domain.Settings;
 import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
@@ -44,14 +45,18 @@ public class SettingsServiceImpl implements SettingsService {
   @Override
   public SettingsDTO updateSettings(SettingsDTO dto) {
     updateSettingsFromDto(dto);
-    eventPublisher.publishEvent(new SettingsUpdatedEvent(dto));
+    SettingsDTO updated = getSettings();
+    if (updated.getNoiseMechanism() == NoiseMechanism.GAUSSIAN
+        && updated.getEpsilon() != null
+        && updated.getEpsilon() > 1.0) {
+      throw new IllegalArgumentException(
+          "Epsilon must be less than or equal to 1.0 when using Gaussian noise");
+    }
+    eventPublisher.publishEvent(new SettingsUpdatedEvent(updated));
     return dto;
   }
 
   private void updateSetting(String name, String value) {
-    if (value == null) {
-      return;
-    }
     Settings setting =
         settingsRepository
             .findById(name)

--- a/agent/backend/src/main/resources/db/migration/V1.8__remove_epsilon_default_from_quality_check.sql
+++ b/agent/backend/src/main/resources/db/migration/V1.8__remove_epsilon_default_from_quality_check.sql
@@ -1,0 +1,1 @@
+UPDATE quality_check SET epsilon_budget = NULL WHERE epsilon_budget IS NOT NULL;

--- a/agent/backend/src/main/resources/db/migration/V1.9__change_noise_mechanism_default_to_laplace.sql
+++ b/agent/backend/src/main/resources/db/migration/V1.9__change_noise_mechanism_default_to_laplace.sql
@@ -1,0 +1,1 @@
+UPDATE settings SET setting_value = 'LAPLACE' WHERE setting_name = 'noiseMechanism';

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtilTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtilTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class DifferentialPrivacyUtilTest {
 
   private static final double EPSILON = 1.0;
+  private static final double DELTA = 1e-6;
   private static final double SENSITIVITY = 1.0;
   private static final int SAMPLE_SIZE = 1000;
 
@@ -396,6 +397,448 @@ class DifferentialPrivacyUtilTest {
       // Should have more close values than medium, and more medium than far
       assertThat(closeCount).isGreaterThan(mediumCount);
       assertThat(mediumCount).isGreaterThan(farCount);
+    }
+  }
+
+  @Nested
+  @DisplayName("Gaussian Noise")
+  class GaussianNoise {
+
+    @Nested
+    @DisplayName("Parameter Validation")
+    class GaussianParameterValidation {
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when epsilon is zero")
+      void shouldRejectZeroEpsilon() {
+        assertThatThrownBy(
+                () -> DifferentialPrivacyUtil.addGaussianNoise(100, 0.0, DELTA, SENSITIVITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Epsilon must be positive");
+      }
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when epsilon is negative")
+      void shouldRejectNegativeEpsilon() {
+        assertThatThrownBy(
+                () -> DifferentialPrivacyUtil.addGaussianNoise(100, -1.0, DELTA, SENSITIVITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Epsilon must be positive");
+      }
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when delta is zero")
+      void shouldRejectZeroDelta() {
+        assertThatThrownBy(
+                () -> DifferentialPrivacyUtil.addGaussianNoise(100, EPSILON, 0.0, SENSITIVITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Delta must be in (0, 1)");
+      }
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when delta is negative")
+      void shouldRejectNegativeDelta() {
+        assertThatThrownBy(
+                () -> DifferentialPrivacyUtil.addGaussianNoise(100, EPSILON, -1e-6, SENSITIVITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Delta must be in (0, 1)");
+      }
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when delta is one or greater")
+      void shouldRejectDeltaOneOrGreater() {
+        assertThatThrownBy(
+                () -> DifferentialPrivacyUtil.addGaussianNoise(100, EPSILON, 1.0, SENSITIVITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Delta must be in (0, 1)");
+      }
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when sensitivity is zero")
+      void shouldRejectZeroSensitivity() {
+        assertThatThrownBy(() -> DifferentialPrivacyUtil.addGaussianNoise(100, EPSILON, DELTA, 0.0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Sensitivity must be positive");
+      }
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when sensitivity is negative")
+      void shouldRejectNegativeSensitivity() {
+        assertThatThrownBy(
+                () -> DifferentialPrivacyUtil.addGaussianNoise(100, EPSILON, DELTA, -1.0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Sensitivity must be positive");
+      }
+
+      @Test
+      @DisplayName("should accept valid parameters")
+      void shouldAcceptValidParameters() {
+        double result = DifferentialPrivacyUtil.addGaussianNoise(100, EPSILON, DELTA, SENSITIVITY);
+        assertThat(result).isGreaterThanOrEqualTo(0.0);
+      }
+    }
+
+    @Nested
+    @DisplayName("Low Count Suppression")
+    class GaussianLowCountSuppression {
+
+      @Test
+      @DisplayName("should suppress very low counts (count = 0)")
+      void shouldSuppressZeroCount() {
+        double result = DifferentialPrivacyUtil.addGaussianNoise(0, EPSILON, DELTA, SENSITIVITY);
+        assertThat(result).isEqualTo(0.0);
+      }
+
+      @Test
+      @DisplayName("should suppress low counts (count = 5)")
+      void shouldSuppressLowCount() {
+        int suppressedCount = 0;
+        for (int i = 0; i < 100; i++) {
+          double result = DifferentialPrivacyUtil.addGaussianNoise(5, EPSILON, DELTA, SENSITIVITY);
+          if (result == 0.0) {
+            suppressedCount++;
+          }
+        }
+        assertThat(suppressedCount).isGreaterThan(80);
+      }
+
+      @RepeatedTest(10)
+      @DisplayName("should handle counts around threshold (count = 9)")
+      void shouldHandleCountsNearThreshold() {
+        double result = DifferentialPrivacyUtil.addGaussianNoise(9, EPSILON, DELTA, SENSITIVITY);
+        assertThat(result).isGreaterThanOrEqualTo(0.0);
+      }
+
+      @Test
+      @DisplayName("should not suppress high counts (count = 100)")
+      void shouldNotSuppressHighCount() {
+        double result = DifferentialPrivacyUtil.addGaussianNoise(100, EPSILON, DELTA, SENSITIVITY);
+        assertThat(result).isGreaterThan(0.0);
+      }
+
+      @Test
+      @DisplayName("should suppress most small counts (count = 8)")
+      void shouldSuppressMostSmallCounts() {
+        int suppressedCount = 0;
+        for (int i = 0; i < 100; i++) {
+          double result = DifferentialPrivacyUtil.addGaussianNoise(8, EPSILON, DELTA, SENSITIVITY);
+          if (result == 0.0) {
+            suppressedCount++;
+          }
+        }
+        // Gaussian has lower variance than Laplace for same epsilon, so expect >50%
+        assertThat(suppressedCount).isGreaterThan(50);
+      }
+    }
+
+    @Nested
+    @DisplayName("Non-Negativity")
+    class GaussianNonNegativity {
+
+      @RepeatedTest(100)
+      @DisplayName("should never return negative values for any count")
+      void shouldNeverReturnNegativeValues() {
+        int[] testCounts = {0, 1, 5, 10, 50, 100, 1000};
+        for (int count : testCounts) {
+          double result =
+              DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, SENSITIVITY);
+          assertThat(result).isGreaterThanOrEqualTo(0.0);
+        }
+      }
+
+      @RepeatedTest(50)
+      @DisplayName("should clamp negative noisy counts to zero")
+      void shouldClampNegativeNoisyCounts() {
+        double result = DifferentialPrivacyUtil.addGaussianNoise(1, 0.1, DELTA, SENSITIVITY);
+        assertThat(result).isGreaterThanOrEqualTo(0.0);
+      }
+    }
+
+    @Nested
+    @DisplayName("Noise Properties")
+    class GaussianNoiseProperties {
+
+      @Test
+      @DisplayName("should add noise - result should differ from original count")
+      void shouldAddNoise() {
+        int count = 1000;
+        boolean foundDifferent = false;
+
+        for (int i = 0; i < 10; i++) {
+          double result =
+              DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, SENSITIVITY);
+          if (result != count) {
+            foundDifferent = true;
+            break;
+          }
+        }
+
+        assertThat(foundDifferent)
+            .as("At least one noisy result should differ from the original count")
+            .isTrue();
+      }
+
+      @Test
+      @DisplayName("should produce different results on repeated calls")
+      void shouldProduceDifferentResults() {
+        int count = 100;
+        List<Double> results = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+          results.add(DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, SENSITIVITY));
+        }
+
+        long distinctCount = results.stream().distinct().count();
+        assertThat(distinctCount).as("Should have multiple distinct noisy values").isGreaterThan(5);
+      }
+
+      @Test
+      @DisplayName("should have noise centered around true count for large counts")
+      void shouldHaveNoiseCenteredAroundTrueCount() {
+        int count = 1000;
+        double sum = 0;
+
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+          sum += DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, SENSITIVITY);
+        }
+
+        double average = sum / SAMPLE_SIZE;
+        assertThat(average).isCloseTo(count, within(count * 0.1));
+      }
+
+      @ParameterizedTest
+      @ValueSource(doubles = {0.1, 0.5, 1.0, 2.0, 5.0})
+      @DisplayName("should add more noise with smaller epsilon")
+      void shouldAddMoreNoiseWithSmallerEpsilon(double epsilon) {
+        int count = 1000;
+        List<Double> results = new ArrayList<>();
+
+        for (int i = 0; i < 100; i++) {
+          results.add(DifferentialPrivacyUtil.addGaussianNoise(count, epsilon, DELTA, SENSITIVITY));
+        }
+
+        double variance = calculateVariance(results);
+        double expectedVariance =
+            2 * Math.pow(SENSITIVITY * Math.sqrt(2.0 * Math.log(1.25 / DELTA)) / epsilon, 2);
+
+        // Allow 80% deviation due to finite sampling and suppression effects
+        assertThat(variance).isCloseTo(expectedVariance, within(expectedVariance * 0.8));
+      }
+    }
+
+    @Nested
+    @DisplayName("Epsilon Budget")
+    class GaussianEpsilonBudget {
+
+      @Test
+      @DisplayName("should add less noise with larger epsilon")
+      void shouldAddLessNoiseWithLargerEpsilon() {
+        int count = 1000;
+
+        List<Double> resultsSmallEpsilon = new ArrayList<>();
+        List<Double> resultsLargeEpsilon = new ArrayList<>();
+
+        for (int i = 0; i < 200; i++) {
+          resultsSmallEpsilon.add(
+              DifferentialPrivacyUtil.addGaussianNoise(count, 0.5, DELTA, SENSITIVITY));
+          resultsLargeEpsilon.add(
+              DifferentialPrivacyUtil.addGaussianNoise(count, 2.0, DELTA, SENSITIVITY));
+        }
+
+        double varianceSmallEpsilon = calculateVariance(resultsSmallEpsilon);
+        double varianceLargeEpsilon = calculateVariance(resultsLargeEpsilon);
+
+        assertThat(varianceSmallEpsilon).isGreaterThan(varianceLargeEpsilon);
+      }
+
+      @ParameterizedTest
+      @ValueSource(doubles = {0.1, 0.5, 1.0, 2.0})
+      @DisplayName("should scale noise inversely with epsilon")
+      void shouldScaleNoiseInverselyWithEpsilon(double epsilon) {
+        int count = 500;
+        List<Double> results = new ArrayList<>();
+
+        for (int i = 0; i < 200; i++) {
+          results.add(DifferentialPrivacyUtil.addGaussianNoise(count, epsilon, DELTA, SENSITIVITY));
+        }
+
+        double meanAbsoluteDeviation = calculateMeanAbsoluteDeviation(results, count);
+
+        // For Gaussian: E[|X - μ|] ≈ σ * sqrt(2/π)
+        double sigma = SENSITIVITY * Math.sqrt(2.0 * Math.log(1.25 / DELTA)) / epsilon;
+        double expectedMAD = sigma * Math.sqrt(2.0 / Math.PI);
+
+        assertThat(meanAbsoluteDeviation).isCloseTo(expectedMAD, within(expectedMAD * 0.5));
+      }
+    }
+
+    @Nested
+    @DisplayName("Delta Impact")
+    class GaussianDeltaImpact {
+
+      @Test
+      @DisplayName("should add more noise with smaller delta")
+      void shouldAddMoreNoiseWithSmallerDelta() {
+        int count = 1000;
+
+        List<Double> resultsLargeDelta = new ArrayList<>();
+        List<Double> resultsSmallDelta = new ArrayList<>();
+
+        for (int i = 0; i < 200; i++) {
+          resultsLargeDelta.add(
+              DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, 1e-3, SENSITIVITY));
+          resultsSmallDelta.add(
+              DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, 1e-8, SENSITIVITY));
+        }
+
+        double varianceLargeDelta = calculateVariance(resultsLargeDelta);
+        double varianceSmallDelta = calculateVariance(resultsSmallDelta);
+
+        assertThat(varianceSmallDelta).isGreaterThan(varianceLargeDelta);
+      }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class GaussianEdgeCases {
+
+      @Test
+      @DisplayName("should handle very large counts")
+      void shouldHandleVeryLargeCounts() {
+        int count = 1_000_000;
+        double result =
+            DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, SENSITIVITY);
+
+        assertThat(result).isGreaterThan(0.0);
+        assertThat(result).isCloseTo(count, within(count * 0.01));
+      }
+
+      @Test
+      @DisplayName("should handle very small epsilon (high privacy)")
+      void shouldHandleVerySmallEpsilon() {
+        int count = 100;
+        double result = DifferentialPrivacyUtil.addGaussianNoise(count, 0.01, DELTA, SENSITIVITY);
+
+        assertThat(result).isGreaterThanOrEqualTo(0.0);
+      }
+
+      @Test
+      @DisplayName("should handle very large epsilon (low privacy)")
+      void shouldHandleVeryLargeEpsilon() {
+        int count = 100;
+        double result = DifferentialPrivacyUtil.addGaussianNoise(count, 100.0, DELTA, SENSITIVITY);
+
+        assertThat(result).isGreaterThan(0.0);
+        assertThat(result).isCloseTo(count, within(5.0));
+      }
+
+      @Test
+      @DisplayName("should handle count exactly at threshold boundary")
+      void shouldHandleCountAtThresholdBoundary() {
+        int count = 10;
+        double result =
+            DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, SENSITIVITY);
+
+        assertThat(result).isGreaterThanOrEqualTo(0.0);
+      }
+
+      @Test
+      @DisplayName("should handle different sensitivity values")
+      void shouldHandleDifferentSensitivity() {
+        int count = 100;
+        double highSensitivity = 10.0;
+
+        double result =
+            DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, highSensitivity);
+
+        assertThat(result).isGreaterThanOrEqualTo(0.0);
+      }
+    }
+
+    @Nested
+    @DisplayName("Statistical Properties")
+    class GaussianStatisticalProperties {
+
+      @Test
+      @DisplayName("should produce noise centered around true count")
+      void shouldProduceCenteredDistribution() {
+        int count = 1000;
+        int aboveCount = 0;
+        int belowCount = 0;
+
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+          double result =
+              DifferentialPrivacyUtil.addGaussianNoise(count, EPSILON, DELTA, SENSITIVITY);
+          if (result > count) {
+            aboveCount++;
+          } else if (result < count) {
+            belowCount++;
+          }
+        }
+
+        // Should be roughly symmetric (within 60/40 split)
+        double ratio = (double) Math.min(aboveCount, belowCount) / Math.max(aboveCount, belowCount);
+        assertThat(ratio).isGreaterThan(0.6);
+      }
+
+      @Test
+      @DisplayName("should have decreasing probability for larger deviations")
+      void shouldHaveDecreasingProbabilityForLargerDeviations() {
+        int count = 1000;
+        int closeCount = 0; // within 5 units
+        int mediumCount = 0; // 5-15 units away
+        int farCount = 0; // more than 15 units away
+
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+          double result = DifferentialPrivacyUtil.addGaussianNoise(count, 1.0, DELTA, SENSITIVITY);
+          double deviation = Math.abs(result - count);
+
+          if (deviation <= 5) {
+            closeCount++;
+          } else if (deviation <= 15) {
+            mediumCount++;
+          } else {
+            farCount++;
+          }
+        }
+
+        assertThat(closeCount).isGreaterThan(mediumCount);
+        assertThat(mediumCount).isGreaterThan(farCount);
+      }
+    }
+
+    @Nested
+    @DisplayName("Standard Deviation Calculation")
+    class GaussianStandardDeviation {
+
+      @Test
+      @DisplayName("should calculate correct standard deviation")
+      void shouldCalculateCorrectSigma() {
+        double sigma =
+            DifferentialPrivacyUtil.calculateGaussianStandardDeviation(EPSILON, DELTA, SENSITIVITY);
+        double expectedSigma = SENSITIVITY * Math.sqrt(2.0 * Math.log(1.25 / DELTA)) / EPSILON;
+        assertThat(sigma).isCloseTo(expectedSigma, within(0.0001));
+      }
+
+      @Test
+      @DisplayName("should increase sigma with smaller epsilon")
+      void shouldIncreaseSigmaWithSmallerEpsilon() {
+        double sigmaSmallEpsilon =
+            DifferentialPrivacyUtil.calculateGaussianStandardDeviation(0.5, DELTA, SENSITIVITY);
+        double sigmaLargeEpsilon =
+            DifferentialPrivacyUtil.calculateGaussianStandardDeviation(2.0, DELTA, SENSITIVITY);
+        assertThat(sigmaSmallEpsilon).isGreaterThan(sigmaLargeEpsilon);
+      }
+
+      @Test
+      @DisplayName("should increase sigma with smaller delta")
+      void shouldIncreaseSigmaWithSmallerDelta() {
+        double sigmaLargeDelta =
+            DifferentialPrivacyUtil.calculateGaussianStandardDeviation(EPSILON, 1e-3, SENSITIVITY);
+        double sigmaSmallDelta =
+            DifferentialPrivacyUtil.calculateGaussianStandardDeviation(EPSILON, 1e-8, SENSITIVITY);
+        assertThat(sigmaSmallDelta).isGreaterThan(sigmaLargeDelta);
+      }
     }
   }
 

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtilTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtilTest.java
@@ -414,7 +414,7 @@ class DifferentialPrivacyUtilTest {
         assertThatThrownBy(
                 () -> DifferentialPrivacyUtil.addGaussianNoise(100, 0.0, DELTA, SENSITIVITY))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Epsilon must be positive");
+            .hasMessageContaining("Epsilon must be in (0, 1]");
       }
 
       @Test
@@ -423,7 +423,16 @@ class DifferentialPrivacyUtilTest {
         assertThatThrownBy(
                 () -> DifferentialPrivacyUtil.addGaussianNoise(100, -1.0, DELTA, SENSITIVITY))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Epsilon must be positive");
+            .hasMessageContaining("Epsilon must be in (0, 1]");
+      }
+
+      @Test
+      @DisplayName("should throw IllegalArgumentException when epsilon is greater than 1")
+      void shouldRejectEpsilonGreaterThanOne() {
+        assertThatThrownBy(
+                () -> DifferentialPrivacyUtil.addGaussianNoise(100, 1.1, DELTA, SENSITIVITY))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Epsilon must be in (0, 1]");
       }
 
       @Test
@@ -499,7 +508,7 @@ class DifferentialPrivacyUtilTest {
             suppressedCount++;
           }
         }
-        assertThat(suppressedCount).isGreaterThan(80);
+        assertThat(suppressedCount).isGreaterThanOrEqualTo(75);
       }
 
       @RepeatedTest(10)
@@ -607,7 +616,7 @@ class DifferentialPrivacyUtilTest {
       }
 
       @ParameterizedTest
-      @ValueSource(doubles = {0.1, 0.5, 1.0, 2.0, 5.0})
+      @ValueSource(doubles = {0.1, 0.5, 0.9, 1.0})
       @DisplayName("should add more noise with smaller epsilon")
       void shouldAddMoreNoiseWithSmallerEpsilon(double epsilon) {
         int count = 1000;
@@ -642,7 +651,7 @@ class DifferentialPrivacyUtilTest {
           resultsSmallEpsilon.add(
               DifferentialPrivacyUtil.addGaussianNoise(count, 0.5, DELTA, SENSITIVITY));
           resultsLargeEpsilon.add(
-              DifferentialPrivacyUtil.addGaussianNoise(count, 2.0, DELTA, SENSITIVITY));
+              DifferentialPrivacyUtil.addGaussianNoise(count, 0.9, DELTA, SENSITIVITY));
         }
 
         double varianceSmallEpsilon = calculateVariance(resultsSmallEpsilon);
@@ -652,7 +661,7 @@ class DifferentialPrivacyUtilTest {
       }
 
       @ParameterizedTest
-      @ValueSource(doubles = {0.1, 0.5, 1.0, 2.0})
+      @ValueSource(doubles = {0.1, 0.5, 0.9, 1.0})
       @DisplayName("should scale noise inversely with epsilon")
       void shouldScaleNoiseInverselyWithEpsilon(double epsilon) {
         int count = 500;
@@ -726,10 +735,10 @@ class DifferentialPrivacyUtilTest {
       @DisplayName("should handle very large epsilon (low privacy)")
       void shouldHandleVeryLargeEpsilon() {
         int count = 100;
-        double result = DifferentialPrivacyUtil.addGaussianNoise(count, 100.0, DELTA, SENSITIVITY);
+        double result = DifferentialPrivacyUtil.addGaussianNoise(count, 1.0, DELTA, SENSITIVITY);
 
         assertThat(result).isGreaterThan(0.0);
-        assertThat(result).isCloseTo(count, within(5.0));
+        assertThat(result).isCloseTo(count, within(20.0));
       }
 
       @Test

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtilTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/DifferentialPrivacyUtilTest.java
@@ -65,6 +65,37 @@ class DifferentialPrivacyUtilTest {
   }
 
   @Nested
+  @DisplayName("Threshold Configuration")
+  class ThresholdConfiguration {
+
+    @Test
+    @DisplayName("should allow setting a custom low count threshold")
+    void shouldAllowSettingCustomThreshold() {
+      DifferentialPrivacyUtil.setLowCountThreshold(25.0);
+      double result = DifferentialPrivacyUtil.addLaplaceNoise(20, EPSILON, SENSITIVITY);
+      assertThat(result).isEqualTo(0.0);
+      DifferentialPrivacyUtil.setLowCountThreshold(10.0);
+    }
+
+    @Test
+    @DisplayName("should throw IllegalArgumentException for negative threshold")
+    void shouldRejectNegativeThreshold() {
+      assertThatThrownBy(() -> DifferentialPrivacyUtil.setLowCountThreshold(-1.0))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Threshold must be non-negative");
+    }
+
+    @Test
+    @DisplayName("should accept zero threshold")
+    void shouldAcceptZeroThreshold() {
+      DifferentialPrivacyUtil.setLowCountThreshold(0.0);
+      double result = DifferentialPrivacyUtil.addLaplaceNoise(1, EPSILON, SENSITIVITY);
+      assertThat(result).isGreaterThanOrEqualTo(0.0);
+      DifferentialPrivacyUtil.setLowCountThreshold(10.0);
+    }
+  }
+
+  @Nested
   @DisplayName("Low Count Suppression")
   class LowCountSuppression {
 

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/domain/ReportMapperTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/domain/ReportMapperTest.java
@@ -25,7 +25,7 @@ public class ReportMapperTest {
     report.setId(101L);
     report.setGeneratedAt(LocalDateTime.of(2025, 5, 12, 14, 30));
     report.setStatus(ReportStatus.GENERATED);
-    report.setEpsilonBudget(1.5f);
+    report.setEpsilonBudget(1.5);
     report.setNumberOfEntities(250);
     report.setNumberOfSecondaryEntities(42);
     report.setResults(
@@ -38,7 +38,7 @@ public class ReportMapperTest {
                     12.5,
                     10,
                     30,
-                    0.4f,
+                    0.4,
                     null,
                     null,
                     Set.of("patient-1", "patient-2")),
@@ -49,7 +49,7 @@ public class ReportMapperTest {
                     0.0,
                     10,
                     30,
-                    0.4f,
+                    0.4,
                     "There is no error message",
                     "stratum_a",
                     Set.of("patient-3")))));
@@ -59,7 +59,7 @@ public class ReportMapperTest {
     assertEquals(101L, reportDTO.getId());
     assertEquals(LocalDateTime.of(2025, 5, 12, 14, 30), reportDTO.getGeneratedAt());
     assertEquals(ReportStatus.GENERATED, reportDTO.getStatus());
-    assertEquals(1.5f, reportDTO.getEpsilonBudget());
+    assertEquals(1.5, reportDTO.getEpsilonBudget());
     assertEquals(250, reportDTO.getNumberOfEntities());
     assertEquals(42, reportDTO.getNumberOfSecondaryEntities());
     assertEquals(2, reportDTO.getResults().size());
@@ -71,7 +71,7 @@ public class ReportMapperTest {
     assertEquals(12.5, firstResult.getObfuscatedValue());
     assertEquals(10, firstResult.getWarningThreshold());
     assertEquals(30, firstResult.getErrorThreshold());
-    assertEquals(0.4f, firstResult.getEpsilon());
+    assertEquals(0.4, firstResult.getEpsilon());
     assertNull(firstResult.getError());
     assertNull(firstResult.getStratum());
     assertTrue(firstResult.getPatients().containsAll(Set.of("patient-1", "patient-2")));
@@ -83,7 +83,7 @@ public class ReportMapperTest {
     assertEquals(0.0, secondResult.getObfuscatedValue());
     assertEquals(10, secondResult.getWarningThreshold());
     assertEquals(30, secondResult.getErrorThreshold());
-    assertEquals(0.4f, secondResult.getEpsilon());
+    assertEquals(0.4, secondResult.getEpsilon());
     assertEquals("There is no error message", secondResult.getError());
     assertEquals("stratum_a", secondResult.getStratum());
     assertEquals(Set.of("patient-3"), secondResult.getPatients());
@@ -139,14 +139,14 @@ public class ReportMapperTest {
     report.setId(105L);
     report.setGeneratedAt(LocalDateTime.of(2024, 1, 15, 9, 45));
     report.setStatus(ReportStatus.GENERATED);
-    report.setEpsilonBudget(2.5f);
+    report.setEpsilonBudget(2.5);
     report.setNumberOfEntities(500);
     report.setNumberOfSecondaryEntities(17);
     report.setResults(
         new ArrayList<>(
             List.of(
                 createResult(
-                    "Check A", 21L, 7, 7.5, 10, 30, 0.5f, null, null, Set.of("patient-x")))));
+                    "Check A", 21L, 7, 7.5, 10, 30, 0.5, null, null, Set.of("patient-x")))));
 
     ReportDTO reportDTO = modelMapper.map(report, ReportDTO.class);
 
@@ -154,7 +154,7 @@ public class ReportMapperTest {
     assertEquals(105L, reportDTO.getId());
     assertEquals(LocalDateTime.of(2024, 1, 15, 9, 45), report.getGeneratedAt());
     assertEquals(ReportStatus.GENERATED, report.getStatus());
-    assertEquals(2.5f, report.getEpsilonBudget());
+    assertEquals(2.5, report.getEpsilonBudget());
     assertEquals(500, report.getNumberOfEntities());
     assertEquals(17, report.getNumberOfSecondaryEntities());
     assertEquals(1, report.getResults().size());
@@ -168,7 +168,7 @@ public class ReportMapperTest {
       Double obfuscatedValue,
       int warningThreshold,
       int errorThreshold,
-      float epsilon,
+      double epsilon,
       String error,
       String stratum,
       Set<String> patients) {

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/domain/ResultMapperTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/domain/ResultMapperTest.java
@@ -97,7 +97,7 @@ public class ResultMapperTest {
     Set<String> idSet = Set.of("patient-1");
     ResultDTO resultDTO = new ResultDTO(9, "ExistingTarget", idSet, null);
 
-    Result result = new Result("Preexisting Check", 42L, null, null, 10, 20, 1.0f, null, null);
+    Result result = new Result("Preexisting Check", 42L, null, null, 10, 20, 1.0, null, null);
 
     modelMapper.map(resultDTO, result);
 
@@ -105,7 +105,7 @@ public class ResultMapperTest {
         new QualityCheck(123L, "Age Check", "Checks ages", "define Age: true");
     qualityCheck.setWarningThreshold(17);
     qualityCheck.setErrorThreshold(31);
-    qualityCheck.setEpsilonBudget(0.75f);
+    qualityCheck.setEpsilonBudget(0.75);
 
     modelMapper.map(qualityCheck, result);
 
@@ -116,25 +116,25 @@ public class ResultMapperTest {
     assertEquals("Age Check", result.getCheckName());
     assertEquals(17, result.getWarningThreshold());
     assertEquals(31, result.getErrorThreshold());
-    assertEquals(0.75f, result.getEpsilon());
+    assertEquals(0.75, result.getEpsilon());
   }
 
   @Test
   void mapQualityCheck_doesNotMapErrorThresholdIntoErrorMessage() {
-    Result result = new Result("Preexisting Check", 42L, null, null, 10, 20, 1.0f, null, null);
+    Result result = new Result("Preexisting Check", 42L, null, null, 10, 20, 1.0, null, null);
 
     QualityCheck qualityCheck =
         new QualityCheck(123L, "Age Check", "Checks ages", "define Age: true");
     qualityCheck.setWarningThreshold(17);
     qualityCheck.setErrorThreshold(31);
-    qualityCheck.setEpsilonBudget(0.75f);
+    qualityCheck.setEpsilonBudget(0.75);
 
     modelMapper.map(qualityCheck, result);
 
     assertNull(result.getError());
     assertEquals(17, result.getWarningThreshold());
     assertEquals(31, result.getErrorThreshold());
-    assertEquals(0.75f, result.getEpsilon());
+    assertEquals(0.75, result.getEpsilon());
   }
 
   @Test

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -1,0 +1,175 @@
+package eu.bbmri_eric.quality.agent.dataquality.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
+import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
+import eu.bbmri_eric.quality.agent.settings.SettingsService;
+import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
+import eu.bbmri_eric.quality.agent.settings.impl.SettingsRepository;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+class ObfuscationStepTest {
+
+  @Autowired private SettingsService settingsService;
+  @Autowired private SettingsRepository settingsRepository;
+  @Autowired private ObfuscationStep step;
+  @Autowired private ReportRepository reportRepository;
+
+  @Test
+  void execute_withAllNonNullRawValues_shouldSetObfuscatedValues() {
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    Result r2 = new Result("c2", 2L, 200, null, 150, 100, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    Report result = step.execute(report);
+
+    assertThat(result).isSameAs(report);
+    assertThat(r1.getObfuscatedValue()).isNotNull().isNotNegative();
+    assertThat(r2.getObfuscatedValue()).isNotNull().isNotNegative();
+  }
+
+  @Test
+  void execute_withNullRawValues_shouldNotSetObfuscatedValues() {
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, null, null, 80, 50, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isNull();
+  }
+
+  @Test
+  void execute_withEmptyResults_shouldNotFail() {
+    Report report = new Report();
+    report.setResults(new ArrayList<>());
+
+    Report result = step.execute(report);
+
+    assertThat(result).isSameAs(report);
+  }
+
+  @Test
+  void execute_withMixedNullAndNonNull_shouldOnlyObfuscateNonNull() {
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    Result r2 = new Result("c2", 2L, null, null, 150, 100, 1.0f, null, null);
+    Result r3 = new Result("c3", 3L, 300, null, 200, 150, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2, r3)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isNotNull().isNotNegative();
+    assertThat(r2.getObfuscatedValue()).isNull();
+    assertThat(r3.getObfuscatedValue()).isNotNull().isNotNegative();
+  }
+
+  @Test
+  void execute_withSingleResult_shouldUseFullEpsilon() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 50, null, 40, 30, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+    step.execute(report);
+    assertThat(r1.getObfuscatedValue()).isNotNull().isNotNegative();
+    assertThat(report.getResults().getFirst().getEpsilon()).isEqualTo(1.0F);
+  }
+
+  @Test
+  void execute_withManyResults_shouldHandleAll() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(10.0).build());
+
+    Report report = new Report();
+    List<Result> results = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      results.add(new Result("c" + i, (long) i, i * 10, null, 80, 50, null, null, null));
+    }
+    report.setResults(results);
+
+    step.execute(report);
+
+    assertThat(report.getResults())
+        .allMatch(
+            r ->
+                r.getObfuscatedValue() != null
+                    && r.getObfuscatedValue() >= 0
+                    && r.getEpsilon() == 0.1F);
+  }
+
+  @Test
+  void execute_shouldNotOverwritePreExistingObfuscatedValueWhenRawIsNull() {
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, null, 42.0, 80, 50, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+    step.execute(report);
+    assertThat(r1.getObfuscatedValue()).isEqualTo(42.0);
+  }
+
+  @Test
+  void getOrder_shouldReturn20() {
+    assertThat(step.getOrder()).isEqualTo(20);
+  }
+
+  @Test
+  void execute_withPersistedReport_shouldPersistObfuscatedValues() {
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    Result r2 = new Result("c2", 2L, 200, null, 150, 100, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+    report = reportRepository.save(report);
+
+    step.execute(report);
+
+    Report saved = reportRepository.findById(report.getId()).orElseThrow();
+    assertThat(saved.getResults())
+        .allMatch(r -> r.getObfuscatedValue() != null && r.getObfuscatedValue() >= 0);
+  }
+
+  @Test
+  void execute_withZeroEpsilonBudget_shouldProduceZeroObfuscatedValues() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(0.0).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+
+    assertThrows(IllegalArgumentException.class, () -> step.execute(report));
+  }
+
+  @Test
+  void execute_shouldObfuscateAllResultsIndependently() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(100.0).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    Result r2 = new Result("c2", 2L, 100, null, 150, 100, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isNotEqualTo(r2.getObfuscatedValue());
+  }
+
+  @Test
+  void execute_withLargeEpsilon_shouldBeCloseToRawValue() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(1000000.0).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isBetween(90.0, 110.0);
+  }
+}

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import eu.bbmri_eric.quality.agent.dataquality.domain.QualityCheck;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
-import eu.bbmri_eric.quality.agent.dataquality.impl.QualityCheckRepository;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
 import eu.bbmri_eric.quality.agent.settings.impl.SettingsRepository;
@@ -30,8 +29,8 @@ class ObfuscationStepTest {
   @Test
   void execute_withAllNonNullRawValues_shouldSetObfuscatedValues() {
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
-    Result r2 = new Result("c2", 2L, 200, null, 150, 100, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0, null, null);
+    Result r2 = new Result("c2", 2L, 200, null, 150, 100, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1, r2)));
 
     Report result = step.execute(report);
@@ -44,7 +43,7 @@ class ObfuscationStepTest {
   @Test
   void execute_withNullRawValues_shouldNotSetObfuscatedValues() {
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, null, null, 80, 50, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, null, null, 80, 50, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1)));
 
     step.execute(report);
@@ -65,9 +64,9 @@ class ObfuscationStepTest {
   @Test
   void execute_withMixedNullAndNonNull_shouldOnlyObfuscateNonNull() {
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
-    Result r2 = new Result("c2", 2L, null, null, 150, 100, 1.0f, null, null);
-    Result r3 = new Result("c3", 3L, 300, null, 200, 150, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0, null, null);
+    Result r2 = new Result("c2", 2L, null, null, 150, 100, 1.0, null, null);
+    Result r3 = new Result("c3", 3L, 300, null, 200, 150, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1, r2, r3)));
 
     step.execute(report);
@@ -106,13 +105,13 @@ class ObfuscationStepTest {
             r ->
                 r.getObfuscatedValue() != null
                     && r.getObfuscatedValue() >= 0
-                    && r.getEpsilon() == 0.1F);
+                    && r.getEpsilon() == 0.1);
   }
 
   @Test
   void execute_shouldNotOverwritePreExistingObfuscatedValueWhenRawIsNull() {
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, null, 42.0, 80, 50, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, null, 42.0, 80, 50, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1)));
     step.execute(report);
     assertThat(r1.getObfuscatedValue()).isEqualTo(42.0);
@@ -126,8 +125,8 @@ class ObfuscationStepTest {
   @Test
   void execute_withPersistedReport_shouldPersistObfuscatedValues() {
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
-    Result r2 = new Result("c2", 2L, 200, null, 150, 100, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0, null, null);
+    Result r2 = new Result("c2", 2L, 200, null, 150, 100, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1, r2)));
     report = reportRepository.save(report);
 
@@ -143,7 +142,7 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(0.0).build());
 
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1)));
 
     assertThrows(IllegalArgumentException.class, () -> step.execute(report));
@@ -154,8 +153,8 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(100.0).build());
 
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
-    Result r2 = new Result("c2", 2L, 100, null, 150, 100, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0, null, null);
+    Result r2 = new Result("c2", 2L, 100, null, 150, 100, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1, r2)));
 
     step.execute(report);
@@ -168,7 +167,7 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(1000000.0).build());
 
     Report report = new Report();
-    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0f, null, null);
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, 1.0, null, null);
     report.setResults(new ArrayList<>(List.of(r1)));
 
     step.execute(report);
@@ -181,11 +180,11 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
 
     QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
-    check1.setEpsilonBudget(0.3f);
+    check1.setEpsilonBudget(0.3);
     qualityCheckRepository.save(check1);
 
     QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
-    check2.setEpsilonBudget(0.5f);
+    check2.setEpsilonBudget(0.5);
     qualityCheckRepository.save(check2);
 
     Report report = new Report();
@@ -195,8 +194,8 @@ class ObfuscationStepTest {
 
     step.execute(report);
 
-    assertThat(r1.getEpsilon()).isEqualTo(0.3f);
-    assertThat(r2.getEpsilon()).isEqualTo(0.5f);
+    assertThat(r1.getEpsilon()).isEqualTo(0.3);
+    assertThat(r2.getEpsilon()).isEqualTo(0.5);
   }
 
   @Test
@@ -204,11 +203,11 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(2.0).build());
 
     QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
-    check1.setEpsilonBudget(1.5f);
+    check1.setEpsilonBudget(1.5);
     qualityCheckRepository.save(check1);
 
     QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
-    check2.setEpsilonBudget(1.0f);
+    check2.setEpsilonBudget(1.0);
     qualityCheckRepository.save(check2);
 
     Report report = new Report();
@@ -218,8 +217,8 @@ class ObfuscationStepTest {
 
     step.execute(report);
 
-    assertThat(r1.getEpsilon()).isEqualTo(1.0f);
-    assertThat(r2.getEpsilon()).isEqualTo(1.0f);
+    assertThat(r1.getEpsilon()).isEqualTo(1.0);
+    assertThat(r2.getEpsilon()).isEqualTo(1.0);
   }
 
   @Test
@@ -227,7 +226,7 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
 
     QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
-    check1.setEpsilonBudget(0.4f);
+    check1.setEpsilonBudget(0.4);
     qualityCheckRepository.save(check1);
 
     Report report = new Report();
@@ -237,8 +236,8 @@ class ObfuscationStepTest {
 
     step.execute(report);
 
-    assertThat(r1.getEpsilon()).isEqualTo(0.4f);
-    assertThat(r2.getEpsilon()).isEqualTo(0.6f);
+    assertThat(r1.getEpsilon()).isEqualTo(0.4);
+    assertThat(r2.getEpsilon()).isEqualTo(0.6);
   }
 
   @Test
@@ -246,11 +245,11 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(2.0).build());
 
     QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
-    check1.setEpsilonBudget(0.8f);
+    check1.setEpsilonBudget(0.8);
     qualityCheckRepository.save(check1);
 
     QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
-    check2.setEpsilonBudget(0.7f);
+    check2.setEpsilonBudget(0.7);
     qualityCheckRepository.save(check2);
 
     Report report = new Report();
@@ -260,8 +259,8 @@ class ObfuscationStepTest {
 
     step.execute(report);
 
-    assertThat(r1.getEpsilon()).isEqualTo(0.8f);
-    assertThat(r2.getEpsilon()).isEqualTo(0.7f);
+    assertThat(r1.getEpsilon()).isEqualTo(0.8);
+    assertThat(r2.getEpsilon()).isEqualTo(0.7);
   }
 
   @Test
@@ -269,11 +268,11 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(2.0).build());
 
     QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
-    check1.setEpsilonBudget(1.2f);
+    check1.setEpsilonBudget(1.2);
     qualityCheckRepository.save(check1);
 
     QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
-    check2.setEpsilonBudget(0.8f);
+    check2.setEpsilonBudget(0.8);
     qualityCheckRepository.save(check2);
 
     Report report = new Report();
@@ -283,8 +282,8 @@ class ObfuscationStepTest {
 
     step.execute(report);
 
-    assertThat(r1.getEpsilon()).isEqualTo(1.2f);
-    assertThat(r2.getEpsilon()).isEqualTo(0.8f);
+    assertThat(r1.getEpsilon()).isEqualTo(1.2);
+    assertThat(r2.getEpsilon()).isEqualTo(0.8);
   }
 
   @Test
@@ -292,7 +291,7 @@ class ObfuscationStepTest {
     settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
 
     QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
-    check1.setEpsilonBudget(0.6f);
+    check1.setEpsilonBudget(0.6);
     qualityCheckRepository.save(check1);
 
     Report report = new Report();
@@ -304,6 +303,6 @@ class ObfuscationStepTest {
 
     assertThat(r1.getObfuscatedValue()).isNull();
     assertThat(r1.getEpsilon()).isNull();
-    assertThat(r2.getEpsilon()).isEqualTo(1.0f);
+    assertThat(r2.getEpsilon()).isEqualTo(1.0);
   }
 }

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -10,12 +10,14 @@ import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
 import eu.bbmri_eric.quality.agent.settings.NoiseMechanism;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
+import eu.bbmri_eric.quality.agent.settings.domain.Settings;
 import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
 import eu.bbmri_eric.quality.agent.settings.impl.SettingsRepository;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,6 +29,11 @@ class ObfuscationStepTest {
   @Autowired private SettingsService settingsService;
   @Autowired private SettingsRepository settingsRepository;
   @Autowired private ObfuscationStep step;
+
+  @BeforeEach
+  void setUp() {
+    settingsRepository.save(new Settings("noiseMechanism", "LAPLACE"));
+  }
 
   @AfterEach
   void tearDown() {

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -8,6 +8,7 @@ import eu.bbmri_eric.quality.agent.dataquality.DifferentialPrivacyUtil;
 import eu.bbmri_eric.quality.agent.dataquality.domain.QualityCheck;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
+import eu.bbmri_eric.quality.agent.settings.NoiseMechanism;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
 import eu.bbmri_eric.quality.agent.settings.impl.SettingsRepository;
@@ -335,5 +336,53 @@ class ObfuscationStepTest {
     step.execute(report);
 
     assertThat(r1.getObfuscatedValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void execute_withGaussianNoise_shouldSetObfuscatedValues() {
+    settingsService.updateSettings(
+        SettingsDTO.builder().epsilon(100.0).noiseMechanism(NoiseMechanism.GAUSSIAN).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", 2L, 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    Report result = step.execute(report);
+
+    assertThat(result).isSameAs(report);
+    assertThat(r1.getObfuscatedValue()).isNotNull().isNotNegative();
+    assertThat(r2.getObfuscatedValue()).isNotNull().isNotNegative();
+  }
+
+  @Test
+  void execute_withLaplaceNoise_shouldSetObfuscatedValues() {
+    settingsService.updateSettings(
+        SettingsDTO.builder().epsilon(100.0).noiseMechanism(NoiseMechanism.LAPLACE).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", 2L, 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    Report result = step.execute(report);
+
+    assertThat(result).isSameAs(report);
+    assertThat(r1.getObfuscatedValue()).isNotNull().isNotNegative();
+    assertThat(r2.getObfuscatedValue()).isNotNull().isNotNegative();
+  }
+
+  @Test
+  void execute_withGaussianNoise_shouldBeCloseToRawValue() {
+    settingsService.updateSettings(
+        SettingsDTO.builder().epsilon(1_000_000.0).noiseMechanism(NoiseMechanism.GAUSSIAN).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isBetween(90.0, 110.0);
   }
 }

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -1,8 +1,10 @@
 package eu.bbmri_eric.quality.agent.dataquality.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import eu.bbmri_eric.quality.agent.dataquality.DifferentialPrivacyUtil;
 import eu.bbmri_eric.quality.agent.dataquality.domain.QualityCheck;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
@@ -12,6 +14,7 @@ import eu.bbmri_eric.quality.agent.settings.impl.SettingsRepository;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,6 +26,12 @@ class ObfuscationStepTest {
   @Autowired private SettingsService settingsService;
   @Autowired private SettingsRepository settingsRepository;
   @Autowired private ObfuscationStep step;
+
+  @AfterEach
+  void tearDown() {
+    DifferentialPrivacyUtil.setLowCountThreshold(10.0);
+  }
+
   @Autowired private ReportRepository reportRepository;
   @Autowired private QualityCheckRepository qualityCheckRepository;
 
@@ -287,22 +296,44 @@ class ObfuscationStepTest {
   }
 
   @Test
-  void execute_withNullRawValueAndPreference_shouldNotConsumeEpsilon() {
-    settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
-
-    QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
-    check1.setEpsilonBudget(0.6);
-    qualityCheckRepository.save(check1);
+  void execute_withHighMinThreshold_shouldSuppressLowCounts() {
+    settingsService.updateSettings(
+        SettingsDTO.builder().epsilon(1_000_000.0).minThreshold(200).build());
 
     Report report = new Report();
-    Result r1 = new Result("c1", check1.getId(), null, null, 80, 50, null, null, null);
-    Result r2 = new Result("c2", 999L, 200, null, 150, 100, null, null, null);
-    report.setResults(new ArrayList<>(List.of(r1, r2)));
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
 
     step.execute(report);
 
-    assertThat(r1.getObfuscatedValue()).isNull();
-    assertThat(r1.getEpsilon()).isNull();
-    assertThat(r2.getEpsilon()).isEqualTo(1.0);
+    assertThat(r1.getObfuscatedValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void execute_withZeroMinThreshold_shouldPreserveCounts() {
+    settingsService.updateSettings(
+        SettingsDTO.builder().epsilon(1_000_000.0).minThreshold(0).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 100, null, 80, 50, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isCloseTo(100.0, within(0.1));
+  }
+
+  @Test
+  void execute_shouldApplyMinThresholdFromSettings() {
+    settingsService.updateSettings(
+        SettingsDTO.builder().epsilon(1_000_000.0).minThreshold(500).build());
+
+    Report report = new Report();
+    Result r1 = new Result("c1", 1L, 300, null, 80, 50, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isEqualTo(0.0);
   }
 }

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -94,7 +94,7 @@ class ObfuscationStepTest {
     report.setResults(new ArrayList<>(List.of(r1)));
     step.execute(report);
     assertThat(r1.getObfuscatedValue()).isNotNull().isNotNegative();
-    assertThat(report.getResults().getFirst().getEpsilon()).isEqualTo(1.0F);
+    assertThat(report.getResults().getFirst().getEpsilon()).isEqualTo(1.0);
   }
 
   @Test

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -3,8 +3,10 @@ package eu.bbmri_eric.quality.agent.dataquality.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import eu.bbmri_eric.quality.agent.dataquality.domain.QualityCheck;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Report;
 import eu.bbmri_eric.quality.agent.dataquality.domain.Result;
+import eu.bbmri_eric.quality.agent.dataquality.impl.QualityCheckRepository;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
 import eu.bbmri_eric.quality.agent.settings.impl.SettingsRepository;
@@ -23,6 +25,7 @@ class ObfuscationStepTest {
   @Autowired private SettingsRepository settingsRepository;
   @Autowired private ObfuscationStep step;
   @Autowired private ReportRepository reportRepository;
+  @Autowired private QualityCheckRepository qualityCheckRepository;
 
   @Test
   void execute_withAllNonNullRawValues_shouldSetObfuscatedValues() {
@@ -171,5 +174,136 @@ class ObfuscationStepTest {
     step.execute(report);
 
     assertThat(r1.getObfuscatedValue()).isBetween(90.0, 110.0);
+  }
+
+  @Test
+  void execute_withPreferencesWithinBudget_shouldUsePreferredEpsilon() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
+
+    QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
+    check1.setEpsilonBudget(0.3f);
+    qualityCheckRepository.save(check1);
+
+    QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
+    check2.setEpsilonBudget(0.5f);
+    qualityCheckRepository.save(check2);
+
+    Report report = new Report();
+    Result r1 = new Result("c1", check1.getId(), 100, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", check2.getId(), 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    step.execute(report);
+
+    assertThat(r1.getEpsilon()).isEqualTo(0.3f);
+    assertThat(r2.getEpsilon()).isEqualTo(0.5f);
+  }
+
+  @Test
+  void execute_withPreferencesExceedingBudget_shouldUseEqualSplit() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(2.0).build());
+
+    QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
+    check1.setEpsilonBudget(1.5f);
+    qualityCheckRepository.save(check1);
+
+    QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
+    check2.setEpsilonBudget(1.0f);
+    qualityCheckRepository.save(check2);
+
+    Report report = new Report();
+    Result r1 = new Result("c1", check1.getId(), 100, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", check2.getId(), 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    step.execute(report);
+
+    assertThat(r1.getEpsilon()).isEqualTo(1.0f);
+    assertThat(r2.getEpsilon()).isEqualTo(1.0f);
+  }
+
+  @Test
+  void execute_withMixedPreferencesWithinBudget_shouldDistributeRemainder() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
+
+    QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
+    check1.setEpsilonBudget(0.4f);
+    qualityCheckRepository.save(check1);
+
+    Report report = new Report();
+    Result r1 = new Result("c1", check1.getId(), 100, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", 999L, 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    step.execute(report);
+
+    assertThat(r1.getEpsilon()).isEqualTo(0.4f);
+    assertThat(r2.getEpsilon()).isEqualTo(0.6f);
+  }
+
+  @Test
+  void execute_withAllResultsHavingPreferencesWithinBudget_shouldUsePreferredValues() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(2.0).build());
+
+    QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
+    check1.setEpsilonBudget(0.8f);
+    qualityCheckRepository.save(check1);
+
+    QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
+    check2.setEpsilonBudget(0.7f);
+    qualityCheckRepository.save(check2);
+
+    Report report = new Report();
+    Result r1 = new Result("c1", check1.getId(), 100, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", check2.getId(), 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    step.execute(report);
+
+    assertThat(r1.getEpsilon()).isEqualTo(0.8f);
+    assertThat(r2.getEpsilon()).isEqualTo(0.7f);
+  }
+
+  @Test
+  void execute_withPreferencesSumEqualToBudget_shouldUsePreferredValues() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(2.0).build());
+
+    QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
+    check1.setEpsilonBudget(1.2f);
+    qualityCheckRepository.save(check1);
+
+    QualityCheck check2 = new QualityCheck("c2", "Check 2", "query2");
+    check2.setEpsilonBudget(0.8f);
+    qualityCheckRepository.save(check2);
+
+    Report report = new Report();
+    Result r1 = new Result("c1", check1.getId(), 100, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", check2.getId(), 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    step.execute(report);
+
+    assertThat(r1.getEpsilon()).isEqualTo(1.2f);
+    assertThat(r2.getEpsilon()).isEqualTo(0.8f);
+  }
+
+  @Test
+  void execute_withNullRawValueAndPreference_shouldNotConsumeEpsilon() {
+    settingsService.updateSettings(SettingsDTO.builder().epsilon(1.0).build());
+
+    QualityCheck check1 = new QualityCheck("c1", "Check 1", "query1");
+    check1.setEpsilonBudget(0.6f);
+    qualityCheckRepository.save(check1);
+
+    Report report = new Report();
+    Result r1 = new Result("c1", check1.getId(), null, null, 80, 50, null, null, null);
+    Result r2 = new Result("c2", 999L, 200, null, 150, 100, null, null, null);
+    report.setResults(new ArrayList<>(List.of(r1, r2)));
+
+    step.execute(report);
+
+    assertThat(r1.getObfuscatedValue()).isNull();
+    assertThat(r1.getEpsilon()).isNull();
+    assertThat(r2.getEpsilon()).isEqualTo(1.0f);
   }
 }

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ObfuscationStepTest.java
@@ -341,7 +341,7 @@ class ObfuscationStepTest {
   @Test
   void execute_withGaussianNoise_shouldSetObfuscatedValues() {
     settingsService.updateSettings(
-        SettingsDTO.builder().epsilon(100.0).noiseMechanism(NoiseMechanism.GAUSSIAN).build());
+        SettingsDTO.builder().epsilon(0.9).noiseMechanism(NoiseMechanism.GAUSSIAN).build());
 
     Report report = new Report();
     Result r1 = new Result("c1", 1L, 100, null, 80, 50, null, null, null);
@@ -375,7 +375,7 @@ class ObfuscationStepTest {
   @Test
   void execute_withGaussianNoise_shouldBeCloseToRawValue() {
     settingsService.updateSettings(
-        SettingsDTO.builder().epsilon(1_000_000.0).noiseMechanism(NoiseMechanism.GAUSSIAN).build());
+        SettingsDTO.builder().epsilon(1.0).noiseMechanism(NoiseMechanism.GAUSSIAN).build());
 
     Report report = new Report();
     Result r1 = new Result("c1", 1L, 100, null, 80, 50, null, null, null);
@@ -383,6 +383,6 @@ class ObfuscationStepTest {
 
     step.execute(report);
 
-    assertThat(r1.getObfuscatedValue()).isBetween(90.0, 110.0);
+    assertThat(r1.getObfuscatedValue()).isBetween(80.0, 120.0);
   }
 }

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/QualityCheckIntegrationTests.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/QualityCheckIntegrationTests.java
@@ -49,7 +49,7 @@ class QualityCheckIntegrationTests {
             "define Test: true",
             10,
             30,
-            1.0f);
+            1.0);
 
     String location =
         mockMvc
@@ -87,7 +87,7 @@ class QualityCheckIntegrationTests {
   @Test
   void create_invalidQualityCheck_blankName_returnsBadRequest() throws Exception {
     QualityCheckCreateDTO createDTO =
-        new QualityCheckCreateDTO("", "Description", "define Test: true", 10, 30, 1.0f);
+        new QualityCheckCreateDTO("", "Description", "define Test: true", 10, 30, 1.0);
 
     mockMvc
         .perform(
@@ -166,7 +166,7 @@ class QualityCheckIntegrationTests {
 
     QualityCheckUpdateDTO updateDTO =
         new QualityCheckUpdateDTO(
-            "Updated Name", "Updated Description", "define Test: false", 20, 50, 2.0f);
+            "Updated Name", "Updated Description", "define Test: false", 20, 50, 2.0);
 
     mockMvc
         .perform(
@@ -189,7 +189,7 @@ class QualityCheckIntegrationTests {
   void update_nonExistingQualityCheck_returnsNotFound() throws Exception {
     QualityCheckUpdateDTO updateDTO =
         new QualityCheckUpdateDTO(
-            "Updated Name", "Updated Description", "define Test: false", 20, 50, 2.0f);
+            "Updated Name", "Updated Description", "define Test: false", 20, 50, 2.0);
 
     mockMvc
         .perform(
@@ -207,7 +207,7 @@ class QualityCheckIntegrationTests {
 
     QualityCheckUpdateDTO updateDTO =
         new QualityCheckUpdateDTO(
-            "Updated Name", "Updated Description", "define Test: false", 150, -10, 2.0f);
+            "Updated Name", "Updated Description", "define Test: false", 150, -10, 2.0);
 
     mockMvc
         .perform(
@@ -258,7 +258,7 @@ class QualityCheckIntegrationTests {
             "Invalid ICD-10 Codes", "How many conditions have invalid ICD-10 codes", null);
     builtInCheck.setWarningThreshold(10);
     builtInCheck.setErrorThreshold(30);
-    builtInCheck.setEpsilonBudget(0.2f);
+    builtInCheck.setEpsilonBudget(0.2);
     QualityCheck savedCheck = qualityCheckRepository.save(builtInCheck);
     Long checkId = savedCheck.getId();
 
@@ -269,7 +269,7 @@ class QualityCheckIntegrationTests {
             null, // Keep query as null for built-in check
             15,
             40,
-            0.5f);
+            0.5);
 
     mockMvc
         .perform(
@@ -288,6 +288,6 @@ class QualityCheckIntegrationTests {
     assertThat(updatedCheck.getName()).isEqualTo("Invalid ICD-10 Codes - Updated");
     assertThat(updatedCheck.getWarningThreshold()).isEqualTo(15);
     assertThat(updatedCheck.getErrorThreshold()).isEqualTo(40);
-    assertThat(updatedCheck.getEpsilonBudget()).isEqualTo(0.5f);
+    assertThat(updatedCheck.getEpsilonBudget()).isEqualTo(0.5);
   }
 }

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ReportServiceImplTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/ReportServiceImplTest.java
@@ -82,7 +82,7 @@ class ReportServiceImplTest {
       Double obfuscatedValue,
       String stratum) {
     Result result =
-        new Result(checkName, checkId, rawValue, obfuscatedValue, 10, 30, 1.0f, null, stratum);
+        new Result(checkName, checkId, rawValue, obfuscatedValue, 10, 30, 1.0, null, stratum);
     report.addResult(result);
   }
 

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsControllerTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsControllerTest.java
@@ -112,19 +112,6 @@ class SettingsControllerTest {
         .andExpect(status().isOk());
   }
 
-  @Test
-  @WithMockUser(username = "admin")
-  void updateSettings_withMissingRequiredFields_shouldReturn400() throws Exception {
-    Map<String, String> incomplete = new HashMap<>();
-    incomplete.put("fhirUrl", "http://localhost:8080/fhir");
-
-    mockMvc
-        .perform(
-            put("/api/settings")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(incomplete)))
-        .andExpect(status().isBadRequest());
-  }
 
   @Test
   void updateSettings_withoutAuthentication_shouldReturn401() throws Exception {

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsControllerTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsControllerTest.java
@@ -26,7 +26,7 @@ class SettingsControllerTest {
         .fhirUrl("http://localhost:8080/fhir")
         .fhirUsername("testuser")
         .fhirPassword("dGVzdHBhc3M=")
-        .epsilon(2.0)
+        .epsilon(0.5)
         .delta(1.0E-8)
         .minThreshold(20)
         .noiseMechanism(NoiseMechanism.GAUSSIAN)
@@ -40,7 +40,7 @@ class SettingsControllerTest {
         .sqlUrl("jdbc:postgresql://localhost:5432/quality")
         .sqlUsername("dbuser")
         .sqlPassword("c2VjcmV0")
-        .epsilon(2.0)
+        .epsilon(0.5)
         .delta(1.0E-8)
         .minThreshold(20)
         .noiseMechanism(NoiseMechanism.GAUSSIAN)
@@ -79,8 +79,45 @@ class SettingsControllerTest {
                 .content(objectMapper.writeValueAsString(validSettingsDTO())))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.fhirUrl").value("http://localhost:8080/fhir"))
-        .andExpect(jsonPath("$.epsilon").value(2.0))
+        .andExpect(jsonPath("$.epsilon").value(validSettingsDTO().getEpsilon()))
         .andExpect(jsonPath("$.noiseMechanism").value("GAUSSIAN"));
+  }
+
+  @Test
+  @WithMockUser(username = "admin")
+  void updateSettings_withGaussianAndEpsilonAboveOne_shouldReturn400() throws Exception {
+    SettingsDTO dto = validSettingsDTO();
+    dto.setEpsilon(2.0);
+    mockMvc
+        .perform(
+            put("/api/settings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isBadRequest());
+    mockMvc
+        .perform(get("/api/settings"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.noiseMechanism").value("GAUSSIAN"))
+        .andExpect(jsonPath("$.epsilon").value(0.5));
+    dto.setNoiseMechanism(NoiseMechanism.LAPLACE);
+    mockMvc
+        .perform(
+            put("/api/settings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.noiseMechanism").value("LAPLACE"))
+        .andExpect(jsonPath("$.epsilon").value(2.0));
+    ;
+    dto.setNoiseMechanism(NoiseMechanism.GAUSSIAN);
+    mockMvc
+        .perform(
+            put("/api/settings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsControllerTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsControllerTest.java
@@ -6,8 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -111,7 +109,6 @@ class SettingsControllerTest {
                 .content(objectMapper.writeValueAsString(dto)))
         .andExpect(status().isOk());
   }
-
 
   @Test
   void updateSettings_withoutAuthentication_shouldReturn401() throws Exception {

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsServiceTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/settings/SettingsServiceTest.java
@@ -72,7 +72,7 @@ class SettingsServiceTest {
             "http://production:8080/fhir",
             "produser",
             base64Password,
-            3.0,
+            0.5,
             1.0E-10,
             50,
             NoiseMechanism.GAUSSIAN);
@@ -83,7 +83,7 @@ class SettingsServiceTest {
     assertEquals("http://production:8080/fhir", result.getFhirUrl());
     assertEquals("produser", result.getFhirUsername());
     assertEquals(base64Password, result.getFhirPassword());
-    assertEquals(3.0, result.getEpsilon());
+    assertEquals(0.5, result.getEpsilon());
     assertEquals(1.0E-10, result.getDelta());
     assertEquals(50, result.getMinThreshold());
     assertEquals(NoiseMechanism.GAUSSIAN, result.getNoiseMechanism());
@@ -207,5 +207,28 @@ class SettingsServiceTest {
             NoiseMechanism.LAPLACE);
 
     assertThrows(IllegalStateException.class, () -> settingsService.updateSettings(dto));
+  }
+
+  @Test
+  void updateSettings_shouldThrowException_whenDbGaussianAndEpsilonAboveOne() {
+    SettingsDTO first =
+        createSettingsDTO(
+            "http://localhost:8080/fhir",
+            "testuser",
+            "dGVzdHBhc3M=",
+            0.5,
+            1.0E-8,
+            10,
+            NoiseMechanism.GAUSSIAN);
+    settingsService.updateSettings(first);
+
+    SettingsDTO second = SettingsDTO.builder().epsilon(2.0).build();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> settingsService.updateSettings(second));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Epsilon must be less than or equal to 1.0 when using Gaussian noise"));
   }
 }

--- a/agent/frontend/src/components/ReportsTable.vue
+++ b/agent/frontend/src/components/ReportsTable.vue
@@ -80,13 +80,6 @@
       fallback: 'N/A',
     },
     {
-      key: 'epsilonBudget',
-      label: 'Budget',
-      headerClass: 'center hide-sm',
-      cellClass: 'center hide-sm',
-      format: 'decimal',
-    },
-    {
       key: 'epsilonUsed',
       label: 'Used',
       headerClass: 'center hide-sm',
@@ -136,8 +129,7 @@
 
   const getEpsilonCellClass = (item) => {
     const used = calculateEpsilonUsed(item);
-    const budget = item.epsilonBudget || 0;
-    return used > budget ? 'center hide-sm danger' : 'center hide-sm';
+    return used > 3.0 ? 'center hide-sm danger' : 'center hide-sm';
   };
 </script>
 

--- a/agent/frontend/src/views/DifferentialPrivacyPage.vue
+++ b/agent/frontend/src/views/DifferentialPrivacyPage.vue
@@ -149,12 +149,12 @@
       );
     } catch (error) {
       console.error('Error saving privacy settings:', error);
+      const apiDetail = error.response?.data?.detail;
       notificationService.error(
         'Save Failed',
-        'Unable to save privacy settings. Please try again.'
+        apiDetail || 'Unable to save privacy settings. Please try again.'
       );
-    } finally {
-      isSaving.value = false;
+    } finally {      isSaving.value = false;
     }
   }
 

--- a/agent/frontend/src/views/ReportDetailPage.vue
+++ b/agent/frontend/src/views/ReportDetailPage.vue
@@ -56,14 +56,6 @@
           <StatCard :number="countPassed()" label="Passed" number-class="text-success" />
         </div>
 
-        <!-- Epsilon Warning Alert -->
-        <div v-if="isOverBudget()" class="alert alert-warning mb-4">
-          <i class="bi bi-exclamation-triangle me-2"></i>
-          <strong>Warning:</strong> Epsilon budget exceeded! Total epsilon used ({{
-            calculateEpsilonUsed().toFixed(2)
-          }}) exceeds budget ({{ report.epsilonBudget.toFixed(2) }})
-        </div>
-
         <div class="mb-4">
           <div class="filter-label">Status:</div>
           <FilterComponent v-model="selectedStatus" :elements="statuses" />


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces significant improvements to the differential privacy utilities and refactors the handling of the epsilon budget throughout the data quality codebase. The most notable changes are the addition of a Gaussian noise mechanism, enhanced configurability for low-count suppression, and a shift from using primitive `float` types to boxed `Double` types for epsilon-related fields and parameters. Additionally, the obfuscation pipeline step is now more flexible and configurable.

**Key changes include:**

### Differential Privacy Enhancements
- Added support for the Gaussian mechanism in addition to the Laplace mechanism, including methods for adding Gaussian noise and calculating its standard deviation in `DifferentialPrivacyUtil`. Also introduced a configurable low-count suppression threshold. [[1]](diffhunk://#diff-7af388cde9bb51bc1857e7836379bd7ea6e91ccc10ccc7df0546ec601d50dbedL6-R26) [[2]](diffhunk://#diff-7af388cde9bb51bc1857e7836379bd7ea6e91ccc10ccc7df0546ec601d50dbedR55-R100)
- Updated Maven configuration to ensure Lombok is available for annotation processing.

### Epsilon Budget Refactoring
- Replaced all usages of primitive `float` types for epsilon/epsilonBudget with boxed `Double` types in domain models (`Result`, `Report`, `QualityCheck`), DTOs, and interfaces for better null-safety and consistency. [[1]](diffhunk://#diff-21ea098373b8fc7756a4548adb7557a2d33d09c1a3779b5ab01d7fa2c8bf97a6L56-R56) [[2]](diffhunk://#diff-a967fbdc4410e9036df86316d7a6e017905bc7551aa0146011521adb27ff4c06L38-R38) [[3]](diffhunk://#diff-11ba3e26687120e82d1367e7473a18823bb3857135165adba3f347fac63b0051L42-R42) [[4]](diffhunk://#diff-64cf0700e5975c9da60c989d50cdf3661bcbe7ebbc5c9bfaa430189f63ba244cL40-R40) [[5]](diffhunk://#diff-64cf0700e5975c9da60c989d50cdf3661bcbe7ebbc5c9bfaa430189f63ba244cL58-R58) [[6]](diffhunk://#diff-8c90c6a29b340136060cbc7670e8f74f109db12e02f3dead6dce6636fd767a1cL46-R46) [[7]](diffhunk://#diff-8c90c6a29b340136060cbc7670e8f74f109db12e02f3dead6dce6636fd767a1cL59-R56) [[8]](diffhunk://#diff-3a3fc9bfc8975fd5ad1e518db4e382b5e7dac07efa2c35627b309df3fb603357L40-R40) [[9]](diffhunk://#diff-3a3fc9bfc8975fd5ad1e518db4e382b5e7dac07efa2c35627b309df3fb603357L52-R52) [[10]](diffhunk://#diff-27945d6b8c6a15561b0941c2cfd6ada5037e2a27eead049f3dc8947a74a0e364L42-R42) [[11]](diffhunk://#diff-27945d6b8c6a15561b0941c2cfd6ada5037e2a27eead049f3dc8947a74a0e364L52-R52) [[12]](diffhunk://#diff-59d042dbae817935097bfa4a465601df73acdfb42c6121d73881abfce98a32c6L15-R15) [[13]](diffhunk://#diff-7619ffdaf8aaef18c7f760298b2300ac43b643ec793973df53e4269db9965eaeL15-R15) [[14]](diffhunk://#diff-fa4ca9a75604cd67d0194ab31cf6cfc40ff4f594559199800ceec8d688e09d47L18-R18) [[15]](diffhunk://#diff-fa4ca9a75604cd67d0194ab31cf6cfc40ff4f594559199800ceec8d688e09d47L30-R30) [[16]](diffhunk://#diff-420a948a0465f049e04ba6c290aea047b2988c7ed5876364c87afe3eb0e6a7acL96-R96) [[17]](diffhunk://#diff-5700e88bb585dc8abe5d9c42af858e1f7b7f8dbd3b2afb3183906ed67c479207L98-R98)

### Obfuscation Pipeline Improvements
- Refactored the `ObfuscationStep` to use dependency-injected services (`SettingsService`, `QualityCheckService`) and moved the noise addition logic into a dedicated method, laying the groundwork for supporting multiple noise mechanisms and per-check configuration.

### Model Mapping Improvements
- Simplified and modernized the custom mapping logic for `ResultDTO` to `Result` using ModelMapper’s post-converter, improving maintainability.

---

These changes collectively improve the flexibility, correctness, and maintainability of the data quality agent’s privacy and reporting features.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
