### PR TITLE
fix: communication regularity between components

### DIFF
--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/server/impl/ServerHealthCheckScheduler.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/server/impl/ServerHealthCheckScheduler.java
@@ -22,6 +22,8 @@ class ServerHealthCheckScheduler {
 
   private static final Logger log = LoggerFactory.getLogger(ServerHealthCheckScheduler.class);
 
+  private static final long ONE_DAY_MS = 86400000L;
+
   private final ServerRepository serverRepository;
   private final SettingsService settingsService;
   private final CentralServerClientFactory clientFactory;
@@ -51,9 +53,13 @@ class ServerHealthCheckScheduler {
 
   /**
    * Periodically checks the registration status of all servers. Updates server status based on the
-   * health check results. Runs every hour.
+   * health check results. Runs once a day with a randomized initial delay to distribute load and
+   * avoid overwhelming the central server.
    */
-  @Scheduled(fixedRate = 3600000)
+  @Scheduled(
+      fixedDelay = ONE_DAY_MS,
+      initialDelayString =
+          "#{T(java.util.concurrent.ThreadLocalRandom).current().nextLong(86400000)}")
   @Transactional
   public void checkAllServerStatuses() {
     String agentId = settingsService.getSettings().getAgentId();

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/dataquality/domain/Agent.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/dataquality/domain/Agent.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -83,6 +84,17 @@ public class Agent {
     }
     AgentInteraction interaction = new AgentInteraction(this.id, type);
     interactions.add(interaction);
+
+    if (type == AgentInteractionType.PING) {
+      long pingCount =
+          interactions.stream().filter(i -> i.getType() == AgentInteractionType.PING).count();
+      if (pingCount > 30) {
+        interactions.stream()
+            .filter(i -> i.getType() == AgentInteractionType.PING)
+            .min(Comparator.comparing(AgentInteraction::getTimestamp))
+            .ifPresent(interactions::remove);
+      }
+    }
   }
 
   public List<Report> getReports() {

--- a/server/backend/src/main/resources/db/migration/V1.3__remove_excessive_ping_interactions.sql
+++ b/server/backend/src/main/resources/db/migration/V1.3__remove_excessive_ping_interactions.sql
@@ -1,0 +1,13 @@
+WITH ranked_pings AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY timestamp DESC) AS rn
+    FROM agent_interaction
+    WHERE type = 'PING'
+)
+DELETE FROM agent_interaction
+WHERE id IN (
+    SELECT id
+    FROM ranked_pings
+    WHERE rn > 30
+);

--- a/server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/domain/AgentTest.java
+++ b/server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/domain/AgentTest.java
@@ -55,6 +55,49 @@ class AgentTest {
   }
 
   @Test
+  void addInteraction_shouldKeepAtMost30MostRecentPingInteractions() {
+    Agent agent = new Agent(UUID.randomUUID().toString());
+    int initialCount = agent.getInteractions().size(); // 1 (REGISTRATION)
+
+    for (int i = 0; i < 30; i++) {
+      agent.addInteraction(AgentInteractionType.PING);
+    }
+
+    assertEquals(initialCount + 30, agent.getInteractions().size());
+
+    agent.addInteraction(AgentInteractionType.PING);
+
+    assertEquals(initialCount + 30, agent.getInteractions().size());
+    long pingCount =
+        agent.getInteractions().stream()
+            .filter(i -> i.getType() == AgentInteractionType.PING)
+            .count();
+    assertEquals(30, pingCount);
+  }
+
+  @Test
+  void addInteraction_shouldNotRemoveNonPingInteractionsWhenExceedingPingLimit() {
+    Agent agent = new Agent(UUID.randomUUID().toString());
+
+    for (int i = 0; i < 35; i++) {
+      agent.addInteraction(AgentInteractionType.PING);
+    }
+
+    agent.addInteraction(AgentInteractionType.REPORT);
+
+    List<AgentInteraction> interactions = agent.getInteractions();
+    long pingCount =
+        interactions.stream().filter(i -> i.getType() == AgentInteractionType.PING).count();
+    long reportCount =
+        interactions.stream().filter(i -> i.getType() == AgentInteractionType.REPORT).count();
+
+    assertEquals(30, pingCount);
+    assertEquals(1, reportCount);
+    assertTrue(
+        interactions.stream().anyMatch(i -> i.getType() == AgentInteractionType.REGISTRATION));
+  }
+
+  @Test
   void addInteraction_shouldAddNewInteraction() {
     Agent agent = new Agent(UUID.randomUUID().toString());
     int initialCount = agent.getInteractions().size();

--- a/server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/impl/AgentControllerTest.java
+++ b/server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/impl/AgentControllerTest.java
@@ -375,6 +375,82 @@ class AgentControllerIntegrationTest {
 
   @Test
   @WithUserDetails("admin")
+  void findById_shouldReturnAtMost30MostRecentPingInteractions_whenExpandIsRequested()
+      throws Exception {
+    String agentId = UUID.randomUUID().toString();
+    Agent agent = new Agent(agentId);
+    for (int i = 0; i < 30; i++) {
+      agent.addInteraction(AgentInteractionType.PING);
+    }
+    agentRepository.save(agent);
+
+    mockMvc
+        .perform(get(API_V_1_AGENTS_ID, agentId).param("expand", "interactions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.interactions").isArray())
+        .andExpect(jsonPath("$.interactions.length()").value(31));
+
+    agent.addInteraction(AgentInteractionType.PING);
+    agentRepository.save(agent);
+
+    mockMvc
+        .perform(get(API_V_1_AGENTS_ID, agentId).param("expand", "interactions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.interactions").isArray())
+        .andExpect(jsonPath("$.interactions.length()").value(31));
+
+    long pingCount =
+        agentRepository.findById(agentId).orElseThrow().getInteractions().stream()
+            .filter(i -> i.getType() == AgentInteractionType.PING)
+            .count();
+    assertEquals(30, pingCount);
+  }
+
+  @Test
+  @WithUserDetails("admin")
+  void findById_shouldPreserveNonPingInteractions_whenPingLimitExceeded() throws Exception {
+    String agentId = UUID.randomUUID().toString();
+    Agent agent = new Agent(agentId);
+    for (int i = 0; i < 30; i++) {
+      agent.addInteraction(AgentInteractionType.PING);
+    }
+    agent.addInteraction(AgentInteractionType.REPORT);
+    agent.addInteraction(AgentInteractionType.REPORT);
+    agent.setVersion("1.0.0");
+    agentRepository.save(agent);
+
+    mockMvc
+        .perform(get(API_V_1_AGENTS_ID, agentId).param("expand", "interactions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.interactions").isArray())
+        .andExpect(jsonPath("$.interactions.length()").value(34));
+
+    Agent savedAgent = agentRepository.findById(agentId).orElseThrow();
+    long pingCount =
+        savedAgent.getInteractions().stream()
+            .filter(i -> i.getType() == AgentInteractionType.PING)
+            .count();
+    long reportCount =
+        savedAgent.getInteractions().stream()
+            .filter(i -> i.getType() == AgentInteractionType.REPORT)
+            .count();
+    long versionUpdateCount =
+        savedAgent.getInteractions().stream()
+            .filter(i -> i.getType() == AgentInteractionType.VERSION_UPDATE)
+            .count();
+    long registrationCount =
+        savedAgent.getInteractions().stream()
+            .filter(i -> i.getType() == AgentInteractionType.REGISTRATION)
+            .count();
+
+    assertEquals(30, pingCount);
+    assertEquals(2, reportCount);
+    assertEquals(1, versionUpdateCount);
+    assertEquals(1, registrationCount);
+  }
+
+  @Test
+  @WithUserDetails("admin")
   void delete_shouldDeleteAgentWhenUserIsAdmin() throws Exception {
     String agentId = UUID.randomUUID().toString();
     Agent agent = new Agent(agentId);

--- a/server/frontend/src/views/AgentInteractionsView.vue
+++ b/server/frontend/src/views/AgentInteractionsView.vue
@@ -94,6 +94,10 @@
               </div>
             </div>
             <div class="card-body p-0">
+              <div class="alert alert-info d-flex align-items-center py-2 mb-0 rounded-0 border-0 border-bottom small" role="alert">
+                <i class="bi bi-info-circle-fill me-2"></i>
+                <span>Only the 30 most recent PING interactions are retained per agent.</span>
+              </div>
               <div class="table-responsive">
                 <table class="table table-hover mb-0 align-middle">
                   <thead class="table-light">


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces a limit on the number of stored PING interactions per agent, ensuring that only the 30 most recent PING interactions are retained. This helps prevent unbounded growth of interaction records and improves performance. Additionally, it updates the server health check scheduler to run less frequently and with a randomized delay to reduce load. Relevant tests and user interface messaging have also been added to reflect these changes.

**Interaction storage and cleanup:**

* The `Agent` domain model now retains only the 30 most recent PING interactions per agent; older PINGs are removed when new ones are added beyond this limit. Other types of interactions are unaffected. (`server/backend/src/main/java/eu/bbmri_eric/quality/server/dataquality/domain/Agent.java`)
* A database migration script removes excessive PING interactions from existing data, keeping only the 30 most recent per agent. (`server/backend/src/main/resources/db/migration/V1.3__remove_excessive_ping_interactions.sql`)

**Testing and validation:**

* Unit and integration tests verify that only 30 PING interactions are kept and that other interaction types are preserved, both in the domain model and in API responses. (`server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/domain/AgentTest.java`, `server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/impl/AgentControllerTest.java`) [[1]](diffhunk://#diff-4d9de31a827b11bf58b4ecf74fa026cf0b066054375b8e055a5d409bc4df764cR57-R99) [[2]](diffhunk://#diff-673a569b27c770a83249e9e94ef089a23ce695fbe13d53398cc2fca75bb07d6bR376-R451)

**User interface:**

* The frontend now displays an informational message to users indicating that only the 30 most recent PING interactions are shown per agent. (`server/frontend/src/views/AgentInteractionsView.vue`)

**Scheduler improvements:**

* The server health check scheduler now runs once per day with a randomized initial delay, instead of every hour, to distribute load and avoid overwhelming the central server. (`agent/backend/src/main/java/eu/bbmri_eric/quality/agent/server/impl/ServerHealthCheckScheduler.java`) [[1]](diffhunk://#diff-0fb1cff1684ede898995690a87118aca87ba5c4cea41608f913eae74b1de6edfR25-R26) [[2]](diffhunk://#diff-0fb1cff1684ede898995690a87118aca87ba5c4cea41608f913eae74b1de6edfL54-R62)

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
