### PR TITLE
feat: brute force protection on login endpoints

### DIFF
--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/config/LoginRateLimitFilter.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/config/LoginRateLimitFilter.java
@@ -1,0 +1,75 @@
+package eu.bbmri_eric.quality.agent.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri_eric.quality.agent.user.LoginAttemptService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Prevents brute-force login attempts on the login endpoint. Blocks requests from IPs that have
+ * exceeded the threshold of failed attempts and records outcomes based on the HTTP response status
+ * after the request has been processed.
+ */
+@Component
+class LoginRateLimitFilter extends OncePerRequestFilter {
+
+  private final LoginAttemptService loginAttemptService;
+  private final ObjectMapper objectMapper;
+
+  LoginRateLimitFilter(LoginAttemptService loginAttemptService, ObjectMapper objectMapper) {
+    this.loginAttemptService = loginAttemptService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+      throws ServletException, IOException {
+    if (!isLoginRequest(req)) {
+      chain.doFilter(req, res);
+      return;
+    }
+
+    String ip = req.getRemoteAddr() != null ? req.getRemoteAddr() : "unknown";
+    if (loginAttemptService.isBlocked(ip)) {
+      ProblemDetail problemDetail = buildResponse(req);
+      res.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+      res.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+      res.getWriter().write(objectMapper.writeValueAsString(problemDetail));
+      return;
+    }
+
+    chain.doFilter(req, res);
+
+    int status = res.getStatus();
+    if (status == HttpStatus.UNAUTHORIZED.value()) {
+      loginAttemptService.recordFailure(ip);
+    } else if (status >= HttpStatus.OK.value() && status < HttpStatus.MULTIPLE_CHOICES.value()) {
+      loginAttemptService.recordSuccess(ip);
+    }
+  }
+
+  private static @NonNull ProblemDetail buildResponse(HttpServletRequest req) {
+    ProblemDetail problemDetail =
+        ProblemDetail.forStatusAndDetail(
+            HttpStatus.TOO_MANY_REQUESTS, "Too many failed attempts. Try again later.");
+    problemDetail.setTitle("Too Many Requests");
+    problemDetail.setInstance(URI.create(req.getRequestURI()));
+    return problemDetail;
+  }
+
+  private boolean isLoginRequest(HttpServletRequest req) {
+    return "/api/auth/login".equals(req.getRequestURI())
+        && "POST".equalsIgnoreCase(req.getMethod());
+  }
+}

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/config/LoginRateLimitFilter.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/config/LoginRateLimitFilter.java
@@ -19,6 +19,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * Prevents brute-force login attempts on the login endpoint. Blocks requests from IPs that have
  * exceeded the threshold of failed attempts and records outcomes based on the HTTP response status
  * after the request has been processed.
+ *
+ * <p>This filter uses {@code getRemoteAddr()} to identify clients. If the application runs behind a
+ * reverse proxy, configure the embedded server to handle forwarded headers (e.g. {@code
+ * server.forward-headers-strategy=native} in Spring Boot) so that {@code getRemoteAddr()} reflects
+ * the original client IP.
  */
 @Component
 class LoginRateLimitFilter extends OncePerRequestFilter {
@@ -40,7 +45,7 @@ class LoginRateLimitFilter extends OncePerRequestFilter {
       return;
     }
 
-    String ip = getClientIp(req);
+    String ip = req.getRemoteAddr() != null ? req.getRemoteAddr() : "unknown";
     if (loginAttemptService.isBlocked(ip)) {
       ProblemDetail problemDetail = buildResponse(req);
       res.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
@@ -71,14 +76,5 @@ class LoginRateLimitFilter extends OncePerRequestFilter {
   private boolean isLoginRequest(HttpServletRequest req) {
     return "/api/auth/login".equals(req.getRequestURI())
         && "POST".equalsIgnoreCase(req.getMethod());
-  }
-
-  private String getClientIp(HttpServletRequest req) {
-    String xfHeader = req.getHeader("X-Forwarded-For");
-    if (xfHeader != null && !xfHeader.isBlank()) {
-      return xfHeader.split(",")[0].trim();
-    }
-    String remoteAddr = req.getRemoteAddr();
-    return remoteAddr != null ? remoteAddr : "unknown";
   }
 }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/config/SecurityConfig.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/config/SecurityConfig.java
@@ -28,14 +28,17 @@ class SecurityConfig {
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final AuthenticationEntryPoint authenticationEntryPoint;
   private final HttpRequestLoggingFilter httpRequestLoggingFilter;
+  private final LoginRateLimitFilter loginRateLimitFilter;
 
   SecurityConfig(
       JwtAuthenticationFilter jwtAuthenticationFilter,
       AuthenticationEntryPoint authenticationEntryPoint,
-      HttpRequestLoggingFilter httpRequestLoggingFilter) {
+      HttpRequestLoggingFilter httpRequestLoggingFilter,
+      LoginRateLimitFilter loginRateLimitFilter) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     this.authenticationEntryPoint = authenticationEntryPoint;
     this.httpRequestLoggingFilter = httpRequestLoggingFilter;
+    this.loginRateLimitFilter = loginRateLimitFilter;
   }
 
   @Bean
@@ -52,6 +55,7 @@ class SecurityConfig {
                     .httpStrictTransportSecurity(hsts -> hsts.maxAgeInSeconds(31536000)))
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(httpRequestLoggingFilter, JwtAuthenticationFilter.class)
+        .addFilterBefore(loginRateLimitFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(HttpMethod.OPTIONS, "/**")

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/LoginAttemptService.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/LoginAttemptService.java
@@ -1,0 +1,31 @@
+package eu.bbmri_eric.quality.agent.user;
+
+/**
+ * Tracks failed login attempts per client IP for brute-force protection. Provides methods to record
+ * successes and failures, check if an IP is blocked, and periodically purge stale entries.
+ */
+public interface LoginAttemptService {
+
+  /**
+   * Records a failed login attempt for the given IP, incrementing the failure count and updating
+   * the timestamp.
+   *
+   * @param ip the client IP address
+   */
+  void recordFailure(String ip);
+
+  /**
+   * Clears the failure history for the given IP, typically called after a successful login.
+   *
+   * @param ip the client IP address
+   */
+  void recordSuccess(String ip);
+
+  /**
+   * Checks whether the given IP is temporarily blocked due to too many failed login attempts.
+   *
+   * @param ip the client IP address
+   * @return true if the IP is currently blocked, false otherwise
+   */
+  boolean isBlocked(String ip);
+}

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImpl.java
@@ -1,0 +1,68 @@
+package eu.bbmri_eric.quality.agent.user.impl;
+
+import eu.bbmri_eric.quality.agent.user.LoginAttemptService;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * In-memory implementation of login attempt tracking. Enforces temporary lockout after a threshold
+ * of consecutive failures and purges stale entries every hour to prevent memory leaks.
+ */
+@Service
+class LoginAttemptServiceImpl implements LoginAttemptService {
+
+  private static final Logger logger = LoggerFactory.getLogger(LoginAttemptServiceImpl.class);
+
+  private static final int MAX_ATTEMPTS = 5;
+  private static final long BLOCK_MILLIS = 15 * 60 * 1000L;
+
+  private final Map<String, Attempt> attempts = new ConcurrentHashMap<>();
+
+  @Override
+  public void recordFailure(String ip) {
+    Attempt a = attempts.computeIfAbsent(ip, k -> new Attempt());
+    a.count++;
+    a.lastFailTime = System.currentTimeMillis();
+  }
+
+  @Override
+  public void recordSuccess(String ip) {
+    attempts.remove(ip);
+  }
+
+  @Override
+  public boolean isBlocked(String ip) {
+    Attempt a = attempts.get(ip);
+    if (a == null || a.count < MAX_ATTEMPTS) {
+      return false;
+    }
+    if (System.currentTimeMillis() - a.lastFailTime > BLOCK_MILLIS) {
+      attempts.remove(ip);
+      return false;
+    }
+    logger.info("Login blocked for IP {} after {} failed attempts", ip, a.count);
+    return true;
+  }
+
+  /** Purges stale entries older than the lockout window every hour. */
+  @Scheduled(fixedDelay = 60, timeUnit = TimeUnit.MINUTES)
+  void purgeOld() {
+    long now = System.currentTimeMillis();
+    attempts.entrySet().removeIf(e -> now - e.getValue().lastFailTime > BLOCK_MILLIS);
+  }
+
+  /** Clears all tracked attempts. Intended for test teardown only. */
+  void clear() {
+    attempts.clear();
+  }
+
+  private static class Attempt {
+    int count;
+    long lastFailTime;
+  }
+}

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImpl.java
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Service;
 /**
  * In-memory implementation of login attempt tracking. Enforces temporary lockout after a threshold
  * of consecutive failures and purges stale entries every hour to prevent memory leaks.
+ *
+ * <p>This implementation uses immutable {@link Attempt} values stored in a {@link
+ * ConcurrentHashMap}, updated atomically via {@code compute}, to remain safe under concurrent
+ * requests from the same IP.
  */
 @Service
 class LoginAttemptServiceImpl implements LoginAttemptService {
@@ -25,9 +29,14 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
 
   @Override
   public void recordFailure(String ip) {
-    Attempt a = attempts.computeIfAbsent(ip, k -> new Attempt());
-    a.count++;
-    a.lastFailTime = System.currentTimeMillis();
+    attempts.compute(
+        ip,
+        (k, v) -> {
+          if (v == null) {
+            return new Attempt(1, System.currentTimeMillis());
+          }
+          return new Attempt(v.count + 1, System.currentTimeMillis());
+        });
   }
 
   @Override
@@ -62,7 +71,12 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
   }
 
   private static class Attempt {
-    int count;
-    long lastFailTime;
+    final int count;
+    final long lastFailTime;
+
+    Attempt(int count, long lastFailTime) {
+      this.count = count;
+      this.lastFailTime = lastFailTime;
+    }
   }
 }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImpl.java
@@ -32,10 +32,11 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
     attempts.compute(
         ip,
         (k, v) -> {
-          if (v == null) {
-            return new Attempt(1, System.currentTimeMillis());
+          long now = System.currentTimeMillis();
+          if (v == null || now - v.lastFailTime > BLOCK_MILLIS) {
+            return new Attempt(1, now);
           }
-          return new Attempt(v.count + 1, System.currentTimeMillis());
+          return new Attempt(v.count + 1, now);
         });
   }
 
@@ -51,7 +52,7 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
       return false;
     }
     if (System.currentTimeMillis() - a.lastFailTime > BLOCK_MILLIS) {
-      attempts.remove(ip);
+      attempts.remove(ip, a);
       return false;
     }
     logger.info("Login blocked for IP {} after {} failed attempts", ip, a.count);

--- a/agent/backend/src/main/resources/application.properties
+++ b/agent/backend/src/main/resources/application.properties
@@ -26,6 +26,7 @@ spring.datasource.hikari.data-source-properties.synchronous=NORMAL
 spring.task.execution.shutdown.await-termination=true
 spring.task.execution.shutdown.await-termination-period=2s
 spring.jpa.open-in-view=false
+server.forward-headers-strategy=native
 server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.http-only=true
 server.servlet.session.cookie.same-site=strict

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImplTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/user/impl/LoginAttemptServiceImplTest.java
@@ -1,0 +1,56 @@
+package eu.bbmri_eric.quality.agent.user.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.bbmri_eric.quality.agent.user.LoginAttemptService;
+import org.junit.jupiter.api.Test;
+
+class LoginAttemptServiceImplTest {
+
+  private final LoginAttemptService service = new LoginAttemptServiceImpl();
+
+  @Test
+  void isBlocked_returnsFalse_forNewIp() {
+    assertThat(service.isBlocked("192.168.1.1")).isFalse();
+  }
+
+  @Test
+  void isBlocked_returnsFalse_afterFewFailures() {
+    String ip = "192.168.1.1";
+    service.recordFailure(ip);
+    service.recordFailure(ip);
+    service.recordFailure(ip);
+    assertThat(service.isBlocked(ip)).isFalse();
+  }
+
+  @Test
+  void isBlocked_returnsTrue_afterMaxFailures() {
+    String ip = "192.168.1.1";
+    for (int i = 0; i < 5; i++) {
+      service.recordFailure(ip);
+    }
+    assertThat(service.isBlocked(ip)).isTrue();
+  }
+
+  @Test
+  void recordSuccess_clearsFailures() {
+    String ip = "192.168.1.1";
+    service.recordFailure(ip);
+    service.recordFailure(ip);
+    service.recordSuccess(ip);
+    assertThat(service.isBlocked(ip)).isFalse();
+  }
+
+  @Test
+  void isBlocked_resetsAfterBlockWindowExpires() {
+    String ip = "192.168.1.1";
+    for (int i = 0; i < 5; i++) {
+      service.recordFailure(ip);
+    }
+    assertThat(service.isBlocked(ip)).isTrue();
+
+    // Simulate time passing beyond the 15-minute window by manipulating the impl directly
+    ((LoginAttemptServiceImpl) service).clear();
+    assertThat(service.isBlocked(ip)).isFalse();
+  }
+}

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/user/impl/UserControllerTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/user/impl/UserControllerTest.java
@@ -35,6 +35,7 @@ public class UserControllerTest {
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserRepository userRepository;
   @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private LoginAttemptServiceImpl loginAttemptService;
 
   @AfterEach
   void tearDown() {
@@ -42,6 +43,7 @@ public class UserControllerTest {
         userRepository.findByUsername(ADMIN_USER).orElseThrow(EntityNotFoundException::new);
     adminUser.setPassword(passwordEncoder.encode(ADMIN_PASS));
     userRepository.save(adminUser);
+    loginAttemptService.clear();
   }
 
   @Test
@@ -243,6 +245,56 @@ public class UserControllerTest {
                     objectMapper.writeValueAsString(
                         new PasswordChangeRequest("current", "newPass123!", "newPass123!"))))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void login_afterMaxFailedAttempts_returnsTooManyRequests() throws Exception {
+    LoginRequest loginRequest = new LoginRequest(ADMIN_USER, "wrongpassword");
+
+    for (int i = 0; i < 5; i++) {
+      mockMvc
+          .perform(
+              post(AUTH_LOGIN_ENDPOINT)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(loginRequest)))
+          .andExpect(status().isUnauthorized());
+    }
+
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isTooManyRequests());
+  }
+
+  @Test
+  void login_successfulLoginAfterFewFailures_resetsCounter() throws Exception {
+    LoginRequest badRequest = new LoginRequest(ADMIN_USER, "wrongpassword");
+    LoginRequest goodRequest = new LoginRequest(ADMIN_USER, ADMIN_PASS);
+
+    for (int i = 0; i < 4; i++) {
+      mockMvc
+          .perform(
+              post(AUTH_LOGIN_ENDPOINT)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(badRequest)))
+          .andExpect(status().isUnauthorized());
+    }
+
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(goodRequest)))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(goodRequest)))
+        .andExpect(status().isOk());
   }
 
   /** Helper method to authenticate and extract JWT token from response */

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/ServerApplication.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/ServerApplication.java
@@ -2,8 +2,10 @@ package eu.bbmri_eric.quality.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ServerApplication {
   public static void main(String[] args) {
     SpringApplication.run(ServerApplication.class, args);

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/LoginRateLimitFilter.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/LoginRateLimitFilter.java
@@ -1,14 +1,13 @@
-package eu.bbmri_eric.quality.agent.config;
+package eu.bbmri_eric.quality.server.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.bbmri_eric.quality.agent.user.LoginAttemptService;
+import eu.bbmri_eric.quality.server.user.LoginAttemptService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
-import org.jspecify.annotations.NonNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -42,7 +41,11 @@ class LoginRateLimitFilter extends OncePerRequestFilter {
 
     String ip = getClientIp(req);
     if (loginAttemptService.isBlocked(ip)) {
-      ProblemDetail problemDetail = buildResponse(req);
+      ProblemDetail problemDetail =
+          ProblemDetail.forStatusAndDetail(
+              HttpStatus.TOO_MANY_REQUESTS, "Too many failed attempts. Try again later.");
+      problemDetail.setTitle("Too Many Requests");
+      problemDetail.setInstance(URI.create(req.getRequestURI()));
       res.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
       res.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
       res.getWriter().write(objectMapper.writeValueAsString(problemDetail));
@@ -57,15 +60,6 @@ class LoginRateLimitFilter extends OncePerRequestFilter {
     } else if (status >= HttpStatus.OK.value() && status < HttpStatus.MULTIPLE_CHOICES.value()) {
       loginAttemptService.recordSuccess(ip);
     }
-  }
-
-  private static @NonNull ProblemDetail buildResponse(HttpServletRequest req) {
-    ProblemDetail problemDetail =
-        ProblemDetail.forStatusAndDetail(
-            HttpStatus.TOO_MANY_REQUESTS, "Too many failed attempts. Try again later.");
-    problemDetail.setTitle("Too Many Requests");
-    problemDetail.setInstance(URI.create(req.getRequestURI()));
-    return problemDetail;
   }
 
   private boolean isLoginRequest(HttpServletRequest req) {

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/LoginRateLimitFilter.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/LoginRateLimitFilter.java
@@ -18,6 +18,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * Prevents brute-force login attempts on the login endpoint. Blocks requests from IPs that have
  * exceeded the threshold of failed attempts and records outcomes based on the HTTP response status
  * after the request has been processed.
+ *
+ * <p>This filter uses {@code getRemoteAddr()} to identify clients. If the application runs behind a
+ * reverse proxy, configure the embedded server to handle forwarded headers (e.g. {@code
+ * server.forward-headers-strategy=native} in Spring Boot) so that {@code getRemoteAddr()} reflects
+ * the original client IP.
  */
 @Component
 class LoginRateLimitFilter extends OncePerRequestFilter {
@@ -39,7 +44,7 @@ class LoginRateLimitFilter extends OncePerRequestFilter {
       return;
     }
 
-    String ip = getClientIp(req);
+    String ip = req.getRemoteAddr() != null ? req.getRemoteAddr() : "unknown";
     if (loginAttemptService.isBlocked(ip)) {
       ProblemDetail problemDetail =
           ProblemDetail.forStatusAndDetail(
@@ -65,14 +70,5 @@ class LoginRateLimitFilter extends OncePerRequestFilter {
   private boolean isLoginRequest(HttpServletRequest req) {
     return "/api/auth/login".equals(req.getRequestURI())
         && "POST".equalsIgnoreCase(req.getMethod());
-  }
-
-  private String getClientIp(HttpServletRequest req) {
-    String xfHeader = req.getHeader("X-Forwarded-For");
-    if (xfHeader != null && !xfHeader.isBlank()) {
-      return xfHeader.split(",")[0].trim();
-    }
-    String remoteAddr = req.getRemoteAddr();
-    return remoteAddr != null ? remoteAddr : "unknown";
   }
 }

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/SecurityConfig.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/SecurityConfig.java
@@ -29,14 +29,17 @@ class SecurityConfig {
   private final AuthenticationEntryPoint authenticationEntryPoint;
   private final HttpRequestLoggingFilter httpRequestLoggingFilter;
   private final AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver;
+  private final LoginRateLimitFilter loginRateLimitFilter;
 
   public SecurityConfig(
       AuthenticationEntryPoint authenticationEntryPoint,
       HttpRequestLoggingFilter httpRequestLoggingFilter,
-      AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver) {
+      AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver,
+      LoginRateLimitFilter loginRateLimitFilter) {
     this.authenticationEntryPoint = authenticationEntryPoint;
     this.httpRequestLoggingFilter = httpRequestLoggingFilter;
     this.authenticationManagerResolver = authenticationManagerResolver;
+    this.loginRateLimitFilter = loginRateLimitFilter;
   }
 
   @Bean
@@ -46,6 +49,7 @@ class SecurityConfig {
         .cors(Customizer.withDefaults())
         .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
         .addFilterBefore(httpRequestLoggingFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(loginRateLimitFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(HttpMethod.OPTIONS, "/**")

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptService.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptService.java
@@ -1,0 +1,31 @@
+package eu.bbmri_eric.quality.server.user;
+
+/**
+ * Tracks failed login attempts per client IP for brute-force protection. Provides methods to record
+ * successes and failures, check if an IP is blocked, and periodically purge stale entries.
+ */
+public interface LoginAttemptService {
+
+  /**
+   * Records a failed login attempt for the given IP, incrementing the failure count and updating
+   * the timestamp.
+   *
+   * @param ip the client IP address
+   */
+  void recordFailure(String ip);
+
+  /**
+   * Clears the failure history for the given IP, typically called after a successful login.
+   *
+   * @param ip the client IP address
+   */
+  void recordSuccess(String ip);
+
+  /**
+   * Checks whether the given IP is temporarily blocked due to too many failed login attempts.
+   *
+   * @param ip the client IP address
+   * @return true if the IP is currently blocked, false otherwise
+   */
+  boolean isBlocked(String ip);
+}

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImpl.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImpl.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Service;
 /**
  * In-memory implementation of login attempt tracking. Enforces temporary lockout after a threshold
  * of consecutive failures and purges stale entries every hour to prevent memory leaks.
+ *
+ * <p>This implementation uses immutable {@link Attempt} values stored in a {@link
+ * ConcurrentHashMap}, updated atomically via {@code compute}, to remain safe under concurrent
+ * requests from the same IP.
  */
 @Service
 class LoginAttemptServiceImpl implements LoginAttemptService {
@@ -24,9 +28,14 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
 
   @Override
   public void recordFailure(String ip) {
-    Attempt a = attempts.computeIfAbsent(ip, k -> new Attempt());
-    a.count++;
-    a.lastFailTime = System.currentTimeMillis();
+    attempts.compute(
+        ip,
+        (k, v) -> {
+          if (v == null) {
+            return new Attempt(1, System.currentTimeMillis());
+          }
+          return new Attempt(v.count + 1, System.currentTimeMillis());
+        });
   }
 
   @Override
@@ -61,7 +70,12 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
   }
 
   private static class Attempt {
-    int count;
-    long lastFailTime;
+    final int count;
+    final long lastFailTime;
+
+    Attempt(int count, long lastFailTime) {
+      this.count = count;
+      this.lastFailTime = lastFailTime;
+    }
   }
 }

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImpl.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImpl.java
@@ -31,10 +31,11 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
     attempts.compute(
         ip,
         (k, v) -> {
-          if (v == null) {
-            return new Attempt(1, System.currentTimeMillis());
+          long now = System.currentTimeMillis();
+          if (v == null || now - v.lastFailTime > BLOCK_MILLIS) {
+            return new Attempt(1, now);
           }
-          return new Attempt(v.count + 1, System.currentTimeMillis());
+          return new Attempt(v.count + 1, now);
         });
   }
 
@@ -50,7 +51,7 @@ class LoginAttemptServiceImpl implements LoginAttemptService {
       return false;
     }
     if (System.currentTimeMillis() - a.lastFailTime > BLOCK_MILLIS) {
-      attempts.remove(ip);
+      attempts.remove(ip, a);
       return false;
     }
     logger.info("Login blocked for IP {} after {} failed attempts", ip, a.count);

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImpl.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImpl.java
@@ -1,0 +1,67 @@
+package eu.bbmri_eric.quality.server.user;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * In-memory implementation of login attempt tracking. Enforces temporary lockout after a threshold
+ * of consecutive failures and purges stale entries every hour to prevent memory leaks.
+ */
+@Service
+class LoginAttemptServiceImpl implements LoginAttemptService {
+
+  private static final Logger logger = LoggerFactory.getLogger(LoginAttemptServiceImpl.class);
+
+  private static final int MAX_ATTEMPTS = 5;
+  private static final long BLOCK_MILLIS = 15 * 60 * 1000L;
+
+  private final Map<String, Attempt> attempts = new ConcurrentHashMap<>();
+
+  @Override
+  public void recordFailure(String ip) {
+    Attempt a = attempts.computeIfAbsent(ip, k -> new Attempt());
+    a.count++;
+    a.lastFailTime = System.currentTimeMillis();
+  }
+
+  @Override
+  public void recordSuccess(String ip) {
+    attempts.remove(ip);
+  }
+
+  @Override
+  public boolean isBlocked(String ip) {
+    Attempt a = attempts.get(ip);
+    if (a == null || a.count < MAX_ATTEMPTS) {
+      return false;
+    }
+    if (System.currentTimeMillis() - a.lastFailTime > BLOCK_MILLIS) {
+      attempts.remove(ip);
+      return false;
+    }
+    logger.info("Login blocked for IP {} after {} failed attempts", ip, a.count);
+    return true;
+  }
+
+  /** Purges stale entries older than the lockout window every hour. */
+  @Scheduled(fixedDelay = 60, timeUnit = TimeUnit.MINUTES)
+  void purgeOld() {
+    long now = System.currentTimeMillis();
+    attempts.entrySet().removeIf(e -> now - e.getValue().lastFailTime > BLOCK_MILLIS);
+  }
+
+  /** Clears all tracked attempts. Intended for test teardown only. */
+  void clear() {
+    attempts.clear();
+  }
+
+  private static class Attempt {
+    int count;
+    long lastFailTime;
+  }
+}

--- a/server/backend/src/main/resources/application.properties
+++ b/server/backend/src/main/resources/application.properties
@@ -32,6 +32,7 @@ app.jwt.expiration=3600000
 server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.http-only=true
 server.servlet.session.cookie.same-site=strict
+server.forward-headers-strategy=native
 logging.level.org.springframework.security=WARN
 logging.level.org.springframework.security.oauth2=INFO
 logging.level.eu.bbmri_eric.quality.server.auth=INFO

--- a/server/backend/src/test/java/eu/bbmri_eric/quality/server/user/AuthControllerTest.java
+++ b/server/backend/src/test/java/eu/bbmri_eric/quality/server/user/AuthControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Base64;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,9 +35,15 @@ class AuthControllerTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
+  @Autowired private LoginAttemptServiceImpl loginAttemptService;
 
   @Value("${app.jwt.expiration:3600000}")
   private long jwtExpiration;
+
+  @AfterEach
+  void tearDown() {
+    loginAttemptService.clear();
+  }
 
   @Test
   @DisplayName("Should return unauthorized for invalid credentials")
@@ -76,6 +83,53 @@ class AuthControllerTest {
 
     String token = extractTokenFromResponse(result);
     validateJwtToken(token, loginTime);
+  }
+
+  @Test
+  @DisplayName("Should block login after max failed attempts")
+  void login_afterMaxFailedAttempts_returnsTooManyRequests() throws Exception {
+    for (int i = 0; i < 5; i++) {
+      mockMvc
+          .perform(
+              post(LOGIN_ENDPOINT)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(createLoginJson(ADMIN_USERNAME, "wrongpassword")))
+          .andExpect(status().isUnauthorized());
+    }
+
+    mockMvc
+        .perform(
+            post(LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createLoginJson(ADMIN_USERNAME, "wrongpassword")))
+        .andExpect(status().isTooManyRequests());
+  }
+
+  @Test
+  @DisplayName("Should reset failure counter after successful login")
+  void login_successfulLoginAfterFewFailures_resetsCounter() throws Exception {
+    for (int i = 0; i < 4; i++) {
+      mockMvc
+          .perform(
+              post(LOGIN_ENDPOINT)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(createLoginJson(ADMIN_USERNAME, "wrongpassword")))
+          .andExpect(status().isUnauthorized());
+    }
+
+    mockMvc
+        .perform(
+            post(LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createLoginJson(ADMIN_USERNAME, ADMIN_PASSWORD)))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            post(LOGIN_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createLoginJson(ADMIN_USERNAME, ADMIN_PASSWORD)))
+        .andExpect(status().isOk());
   }
 
   @Test

--- a/server/backend/src/test/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImplTest.java
+++ b/server/backend/src/test/java/eu/bbmri_eric/quality/server/user/LoginAttemptServiceImplTest.java
@@ -1,0 +1,54 @@
+package eu.bbmri_eric.quality.server.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LoginAttemptServiceImplTest {
+
+  private final LoginAttemptService service = new LoginAttemptServiceImpl();
+
+  @Test
+  void isBlocked_returnsFalse_forNewIp() {
+    assertThat(service.isBlocked("192.168.1.1")).isFalse();
+  }
+
+  @Test
+  void isBlocked_returnsFalse_afterFewFailures() {
+    String ip = "192.168.1.1";
+    service.recordFailure(ip);
+    service.recordFailure(ip);
+    service.recordFailure(ip);
+    assertThat(service.isBlocked(ip)).isFalse();
+  }
+
+  @Test
+  void isBlocked_returnsTrue_afterMaxFailures() {
+    String ip = "192.168.1.1";
+    for (int i = 0; i < 5; i++) {
+      service.recordFailure(ip);
+    }
+    assertThat(service.isBlocked(ip)).isTrue();
+  }
+
+  @Test
+  void recordSuccess_clearsFailures() {
+    String ip = "192.168.1.1";
+    service.recordFailure(ip);
+    service.recordFailure(ip);
+    service.recordSuccess(ip);
+    assertThat(service.isBlocked(ip)).isFalse();
+  }
+
+  @Test
+  void isBlocked_resetsAfterBlockWindowExpires() {
+    String ip = "192.168.1.1";
+    for (int i = 0; i < 5; i++) {
+      service.recordFailure(ip);
+    }
+    assertThat(service.isBlocked(ip)).isTrue();
+
+    ((LoginAttemptServiceImpl) service).clear();
+    assertThat(service.isBlocked(ip)).isFalse();
+  }
+}


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces brute-force protection for login endpoints in both the agent and server backends by rate-limiting failed login attempts per client IP. The main changes include a new filter that blocks login requests after too many failures, an in-memory service for tracking attempts, and integration of these components into the security filter chain. Comprehensive tests are also added to verify the correct behavior.

**Brute-force protection and rate limiting:**

* Added `LoginRateLimitFilter` in both agent and server backends to intercept login requests, block requests from IPs with too many failed attempts, and return a `429 Too Many Requests` response. [[1]](diffhunk://#diff-f9bbc781c1d6d5841ce7d16ae52a67db4bd21f187086995a1b6e952a365ec08bR1-R84) [[2]](diffhunk://#diff-3d808e5a04df01ccdd69bac5760d3f05445f218cd820e224ceee7fc72caecce3R1-R78)
* Implemented `LoginAttemptService` interface and in-memory `LoginAttemptServiceImpl` to track failed login attempts, enforce a 15-minute lockout after 5 failures, and periodically purge stale entries. [[1]](diffhunk://#diff-e2f84c488bb990da12152f8471b6509c89331a46bb33ee6666062eba2147ed60R1-R31) [[2]](diffhunk://#diff-49cb09127c1230c72d76e89a6ad247e8cb269d67bd67370aa8d3d0cc73d099b0R1-R68) [[3]](diffhunk://#diff-f711cce9260062f2fe74d3e4d0fe2eb6bd45d497ed1952b9005f05230ec5f322R1-R31) [[4]](diffhunk://#diff-dfc45b9ed61f929ae64728d3dcde9d689a0e5d1efb9df0a6cd5aa88c28371acfR1-R67)

**Security configuration:**

* Integrated `LoginRateLimitFilter` into the Spring Security filter chain in both agent and server backends, ensuring it runs before authentication. [[1]](diffhunk://#diff-efe268e040e3dc84bb092fce88d4074a73e2554fc3cc0616b918be7bbba29f18R31-R41) [[2]](diffhunk://#diff-efe268e040e3dc84bb092fce88d4074a73e2554fc3cc0616b918be7bbba29f18R58) [[3]](diffhunk://#diff-7d4c425306223159cbe867661d3a918960588810d37e788f58831dac87122357R32-R42) [[4]](diffhunk://#diff-7d4c425306223159cbe867661d3a918960588810d37e788f58831dac87122357R52)
* Enabled scheduling in the server backend to support periodic purging of stale login attempt entries.

**Testing:**

* Added unit tests for `LoginAttemptServiceImpl` and integration tests to verify lockout and reset behavior on the login endpoint. [[1]](diffhunk://#diff-a82f90cd0adf8eaa63c6798bcc1d6911f0e0ff8848dfb81b74cd9c95de4290c1R1-R56) [[2]](diffhunk://#diff-3f1d13092357959d82d355bb269b7c294faffb2f95dae9641400c760169e8eabR250-R299)
* Ensured test isolation by clearing login attempt state after each test in relevant test classes.

These changes significantly enhance the application's security posture by mitigating brute-force login attacks.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
