### PR TITLE
feat(server): add constraint on max number of stored reports per agent

### DIFF
--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/SecurityConfig.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/common/SecurityConfig.java
@@ -106,7 +106,7 @@ class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/v1/settings/oidc")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/settings")
-                    .authenticated()
+                    .hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PATCH, "/api/v1/settings/oidc")
                     .hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PATCH, "/api/v1/settings")

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/dataquality/domain/Agent.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/dataquality/domain/Agent.java
@@ -106,6 +106,10 @@ public class Agent {
     reports.add(report);
   }
 
+  public void removeReport(Report report) {
+    reports.remove(report);
+  }
+
   public List<Group> getGroups() {
     return groups.stream().toList();
   }

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/dataquality/impl/ReportServiceImpl.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/dataquality/impl/ReportServiceImpl.java
@@ -11,12 +11,17 @@ import eu.bbmri_eric.quality.server.dataquality.dto.QualityCheckResultDTO;
 import eu.bbmri_eric.quality.server.dataquality.dto.ReportCreateRequest;
 import eu.bbmri_eric.quality.server.dataquality.dto.ReportDTO;
 import eu.bbmri_eric.quality.server.dataquality.event.ReportSubmittedEvent;
+import eu.bbmri_eric.quality.server.setting.SettingService;
 import eu.bbmri_eric.quality.server.user.AuthenticationContextService;
 import eu.bbmri_eric.quality.server.user.UserDTO;
 import eu.bbmri_eric.quality.server.user.UserRole;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.jspecify.annotations.NonNull;
 import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,12 +34,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 class ReportServiceImpl implements ReportService {
+  private static final Logger logger = LoggerFactory.getLogger(ReportServiceImpl.class);
+  private static final int DEFAULT_RETENTION = 3;
+
   private final AgentRepository agentRepository;
   private final ReportRepository reportRepository;
   private final QualityCheckRepository qualityCheckRepository;
   private final AuthenticationContextService authenticationContextService;
   private final ApplicationEventPublisher eventPublisher;
   private final ModelMapper modelMapper;
+  private final SettingService settingService;
 
   public ReportServiceImpl(
       AgentRepository agentRepository,
@@ -42,13 +51,15 @@ class ReportServiceImpl implements ReportService {
       QualityCheckRepository qualityCheckRepository,
       AuthenticationContextService authenticationContextService,
       ApplicationEventPublisher eventPublisher,
-      ModelMapper modelMapper) {
+      ModelMapper modelMapper,
+      SettingService settingService) {
     this.agentRepository = agentRepository;
     this.reportRepository = reportRepository;
     this.qualityCheckRepository = qualityCheckRepository;
     this.authenticationContextService = authenticationContextService;
     this.eventPublisher = eventPublisher;
     this.modelMapper = modelMapper;
+    this.settingService = settingService;
   }
 
   @Override
@@ -65,6 +76,42 @@ class ReportServiceImpl implements ReportService {
     agent.addReport(report);
     agentRepository.saveAndFlush(agent);
     eventPublisher.publishEvent(new ReportSubmittedEvent(this, agentId, report.getId()));
+    applyRetentionPolicy(agent);
+  }
+
+  private void applyRetentionPolicy(Agent agent) {
+    int retention = getReportRetention();
+    int maxReports = retention + 2; // oldest + latest + n additional latest reports
+
+    List<Report> reports =
+        agent.getReports().stream().sorted(Comparator.comparing(Report::getTimestamp)).toList();
+
+    if (reports.size() <= maxReports) {
+      return;
+    }
+
+    int deleteCount = reports.size() - maxReports;
+    List<Report> toDelete = new ArrayList<>();
+    for (int i = 1; i <= deleteCount; i++) {
+      toDelete.add(reports.get(i));
+    }
+
+    toDelete.forEach(agent::removeReport);
+    reportRepository.deleteAll(toDelete);
+
+    logger.info(
+        "Applied retention policy for agent {}: deleted {} reports, keeping {} reports",
+        agent.getId(),
+        deleteCount,
+        maxReports);
+  }
+
+  private int getReportRetention() {
+    var settings = settingService.getSettings();
+    if (settings != null && settings.getReportRetention() != null) {
+      return settings.getReportRetention();
+    }
+    return DEFAULT_RETENTION;
   }
 
   private @NonNull Report parseReportDTO(ReportCreateRequest createRequest) {

--- a/server/backend/src/main/java/eu/bbmri_eric/quality/server/setting/SettingDTO.java
+++ b/server/backend/src/main/java/eu/bbmri_eric/quality/server/setting/SettingDTO.java
@@ -1,8 +1,22 @@
 package eu.bbmri_eric.quality.server.setting;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 
 @Schema(description = "Settings Data Transfer Object")
 public class SettingDTO {
+
+  @Schema(description = "Maximum number of reports to retain per agent", example = "3")
+  @Min(1)
+  private Integer reportRetention;
+
   public SettingDTO() {}
+
+  public Integer getReportRetention() {
+    return reportRetention;
+  }
+
+  public void setReportRetention(Integer reportRetention) {
+    this.reportRetention = reportRetention;
+  }
 }

--- a/server/backend/src/main/resources/db/migration/V1.4__add_report_retention_setting.sql
+++ b/server/backend/src/main/resources/db/migration/V1.4__add_report_retention_setting.sql
@@ -1,0 +1,2 @@
+INSERT INTO setting (setting_name, setting_value)
+VALUES ('reportRetention', '3');

--- a/server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/impl/ReportControllerTest.java
+++ b/server/backend/src/test/java/eu/bbmri_eric/quality/server/dataquality/impl/ReportControllerTest.java
@@ -14,6 +14,7 @@ import eu.bbmri_eric.quality.server.dataquality.domain.Report;
 import eu.bbmri_eric.quality.server.dataquality.dto.QualityCheckResultDTO;
 import eu.bbmri_eric.quality.server.dataquality.dto.ReportCreateRequest;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -806,6 +807,45 @@ class ReportControllerTest {
         .andExpect(jsonPath("$._embedded.reports.length()").value(2))
         .andExpect(jsonPath("$._embedded.reports[0].id").value(newerReport.getId()))
         .andExpect(jsonPath("$._embedded.reports[1].id").value(olderReport.getId()));
+  }
+
+  @Test
+  @WithUserDetails("admin")
+  void create_shouldApplyRetentionPolicyAndRemoveMiddleReports() throws Exception {
+    seedReportCountForAgent(testAgent, 5);
+
+    Agent agent = agentRepository.findById(testAgentId).get();
+    List<Report> reportsBefore =
+        agent.getReports().stream().sorted(Comparator.comparing(Report::getTimestamp)).toList();
+    assertEquals(5, reportsBefore.size());
+    String oldestReportId = reportsBefore.get(0).getId();
+    String secondOldestReportId = reportsBefore.get(1).getId();
+
+    List<QualityCheckResultDTO> results = List.of(new QualityCheckResultDTO("hash1", 0.95));
+    ReportCreateRequest createRequest = new ReportCreateRequest(results);
+    mockMvc
+        .perform(
+            post(API_V1_AGENTS_REPORTS, testAgentId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createRequest)))
+        .andExpect(status().isCreated());
+
+    agent = agentRepository.findById(testAgentId).get();
+    List<Report> reportsAfter =
+        agent.getReports().stream().sorted(Comparator.comparing(Report::getTimestamp)).toList();
+    assertEquals(5, reportsAfter.size());
+    assertEquals(oldestReportId, reportsAfter.get(0).getId());
+    assertTrue(
+        reportsAfter.stream().noneMatch(r -> r.getId().equals(secondOldestReportId)),
+        "Second oldest report should have been deleted by retention policy");
+  }
+
+  private void seedReportCountForAgent(Agent agent, int count) {
+    for (int i = 0; i < count; i++) {
+      Report report = new Report();
+      agent.addReport(report);
+    }
+    agentRepository.saveAndFlush(agent);
   }
 
   private void seedReportsWithTotals(int... totals) {

--- a/server/backend/src/test/java/eu/bbmri_eric/quality/server/setting/SettingsControllerTest.java
+++ b/server/backend/src/test/java/eu/bbmri_eric/quality/server/setting/SettingsControllerTest.java
@@ -3,8 +3,10 @@ package eu.bbmri_eric.quality.server.setting;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -25,6 +27,7 @@ class SettingsControllerTest {
   public static final String API_V1_SETTINGS = "/api/v1/settings";
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
 
   @Test
   @WithUserDetails("admin")
@@ -51,11 +54,8 @@ class SettingsControllerTest {
 
   @Test
   @WithMockUser(roles = "USER")
-  void getSettings_withUserRole_shouldBeAccessible() throws Exception {
-    mockMvc
-        .perform(get(API_V1_SETTINGS))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  void getSettings_withUserRole_shouldReturn403() throws Exception {
+    mockMvc.perform(get(API_V1_SETTINGS)).andExpect(status().isForbidden());
   }
 
   @Test
@@ -64,5 +64,44 @@ class SettingsControllerTest {
     mockMvc
         .perform(patch(API_V1_SETTINGS).contentType(MediaType.APPLICATION_JSON).content("{}"))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void getSettings_withAdminRole_containsReportRetentionWithDefaultValue() throws Exception {
+    mockMvc
+        .perform(get(API_V1_SETTINGS))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.reportRetention").value(3));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void patchReportRetention_withAdminRole_updatesValue() throws Exception {
+    SettingDTO dto = new SettingDTO();
+    dto.setReportRetention(5);
+
+    mockMvc
+        .perform(
+            patch(API_V1_SETTINGS)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.reportRetention").value(5));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void patchReportRetention_withInvalidValue_returnsBadRequest() throws Exception {
+    SettingDTO dto = new SettingDTO();
+    dto.setReportRetention(0);
+
+    mockMvc
+        .perform(
+            patch(API_V1_SETTINGS)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/server/frontend/src/components/layout/Sidebar.vue
+++ b/server/frontend/src/components/layout/Sidebar.vue
@@ -93,6 +93,15 @@
               <span>Profile</span>
             </router-link>
             <router-link
+              to="/settings"
+              class="nav-link nav-subitem"
+              :class="{ active: $route.name === 'Settings' }"
+              @click="closeMobileMenu"
+            >
+              <i class="bi bi-sliders"></i>
+              <span>General</span>
+            </router-link>
+            <router-link
               to="/oidc-settings"
               class="nav-link nav-subitem"
               :class="{ active: $route.name === 'OidcSettings' }"

--- a/server/frontend/src/stores/settingsStore.js
+++ b/server/frontend/src/stores/settingsStore.js
@@ -11,6 +11,9 @@ const settings = ref({
   oidcAuthorityLogo: '',
   oidcSwaggerRedirectUrl: '',
 });
+const generalSettings = ref({
+  reportRetention: 3,
+});
 const loading = ref(false);
 const error = ref(null);
 
@@ -42,10 +45,40 @@ async function updateOidcSettings() {
   }
 }
 
+async function fetchGeneralSettings() {
+  loading.value = true;
+  error.value = null;
+  try {
+    const response = await api.get('/v1/settings');
+    generalSettings.value = response.data;
+  } catch (err) {
+    error.value = 'Failed to load general settings. Please try again.';
+    console.error('Failed to load general settings:', err);
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function updateGeneralSettings() {
+  loading.value = true;
+  error.value = null;
+  try {
+    await api.patch('/v1/settings', generalSettings.value);
+  } catch (err) {
+    error.value = err.response?.data?.message || 'Failed to save general settings. Please try again.';
+    console.error('Failed to save general settings:', err);
+  } finally {
+    loading.value = false;
+  }
+}
+
 export default {
   settings,
+  generalSettings,
   loading,
   error,
   fetchOidcSettings,
   updateOidcSettings,
+  fetchGeneralSettings,
+  updateGeneralSettings,
 };

--- a/server/frontend/src/views/Settings.vue
+++ b/server/frontend/src/views/Settings.vue
@@ -1,28 +1,66 @@
 <template>
   <div class="container-fluid py-3 py-md-4">
+    <PageHeader title="General Settings" subtitle="Configure application-wide settings">
+      <template #icon>
+        <i class="bi bi-sliders fs-2 text-primary"></i>
+      </template>
+    </PageHeader>
+
     <div class="row justify-content-center">
       <div class="col-12 col-lg-8">
-        <div class="card border-0 shadow-sm mobile-settings-card">
-          <div class="card-body text-center py-4 py-md-5">
-            <div class="mb-3 mb-md-4">
-              <svg
-                width="48"
-                height="48"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="text-primary settings-icon"
-              >
-                <path
-                  d="M19.14,12.94c0.04-0.3,0.06-0.61,0.06-0.94c0-0.32-0.02-0.64-0.07-0.94l2.03-1.58c0.18-0.14,0.23-0.41,0.12-0.61 l-1.92-3.32c-0.12-0.22-0.37-0.29-0.59-0.22l-2.39,0.96c-0.5-0.38-1.03-0.7-1.62-0.94L14.4,2.81c-0.04-0.24-0.24-0.41-0.48-0.41 h-3.84c-0.24,0-0.43,0.17-0.47,0.41L9.25,5.35C8.66,5.59,8.12,5.92,7.63,6.29L5.24,5.33c-0.22-0.08-0.47,0-0.59,0.22L2.74,8.87 C2.62,9.08,2.66,9.34,2.86,9.48l2.03,1.58C4.84,11.36,4.82,11.69,4.82,12s0.02,0.64,0.07,0.94l-2.03,1.58 c-0.18,0.14-0.23,0.41-0.12,0.61l1.92,3.32c0.12,0.22,0.37,0.29,0.59,0.22l2.39-0.96c0.5,0.38,1.03,0.7,1.62,0.94l0.36,2.54 c0.05,0.24,0.24,0.41,0.48,0.41h3.84c0.24,0,0.44-0.17,0.47-0.41l0.36-2.54c0.59-0.24,1.13-0.56,1.62-0.94l2.39,0.96 c0.22,0.08,0.47,0,0.59-0.22l1.92-3.32c0.12-0.22,0.07-0.47-0.12-0.61L19.14,12.94z M12,15.6c-1.98,0-3.6-1.62-3.6-3.6 s1.62-3.6,3.6-3.6s3.6,1.62,3.6,3.6S13.98,15.6,12,15.6z"
-                  fill="currentColor"
-                />
-              </svg>
-            </div>
-            <h2 class="h4 h-md-3 fw-bold text-dark mb-2 mb-md-3">Settings</h2>
-            <p class="text-muted mb-0 settings-description">
-              This is the settings page - configuration options will be implemented here.
+        <div class="card border-0 shadow-sm">
+          <div class="card-body p-4">
+            <h3 class="h5 fw-bold mb-3">
+              <i class="bi bi-gear-fill me-2 text-primary"></i>
+              Application Configuration
+            </h3>
+            <p class="text-muted mb-4">
+              Configure general application settings that affect data retention and system behavior.
             </p>
+
+            <div v-if="isInitializing" class="text-center py-5">
+              <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+              </div>
+              <p class="text-muted mt-3">Loading settings...</p>
+            </div>
+
+            <form v-else @submit.prevent="saveSettings">
+              <div class="mb-3">
+                <label for="reportRetention" class="form-label">
+                  Report Retention
+                </label>
+                <input
+                  id="reportRetention"
+                  v-model.number="generalSettings.reportRetention"
+                  type="number"
+                  class="form-control"
+                  placeholder="3"
+                />
+                <div class="form-text">
+                  Maximum number of reports to retain per agent. Older reports will be removed.
+                </div>
+              </div>
+
+              <div class="d-flex flex-wrap button-group">
+                <button type="submit" class="btn btn-primary" :disabled="loading">
+                  <span
+                    v-if="loading"
+                    class="spinner-border spinner-border-sm me-2"
+                    role="status"
+                  ></span>
+                  {{ loading ? 'Saving...' : 'Save Settings' }}
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  :disabled="loading"
+                  @click="resetSettings"
+                >
+                  Reset
+                </button>
+              </div>
+            </form>
           </div>
         </div>
       </div>
@@ -30,48 +68,60 @@
   </div>
 </template>
 
-<script setup></script>
+<script setup>
+  import { ref, onMounted } from 'vue';
+  import settingsStore from '@/stores/settingsStore';
+  import { notificationService } from '@/services/notificationService';
+  import PageHeader from '@/components/ui/PageHeader.vue';
+
+  const { generalSettings, loading, error } = settingsStore;
+  const isInitializing = ref(true);
+
+  async function saveSettings() {
+    await settingsStore.updateGeneralSettings();
+
+    if (error.value) {
+      notificationService.error('Error', error.value, { duration: 5000, autoClose: true });
+    } else {
+      notificationService.success(
+        'Settings Saved',
+        'General settings have been updated successfully.',
+        { duration: 3000, autoClose: true }
+      );
+    }
+  }
+
+  async function resetSettings() {
+    await settingsStore.fetchGeneralSettings();
+  }
+
+  onMounted(async () => {
+    await settingsStore.fetchGeneralSettings();
+    isInitializing.value = false;
+  });
+</script>
 
 <style scoped>
-  .mobile-settings-card {
+  .form-label {
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+  }
+
+  .card {
     border-radius: 12px;
   }
 
-  .settings-icon {
-    width: 48px;
-    height: 48px;
+  .button-group {
+    gap: 0.5rem;
   }
 
-  .settings-description {
-    font-size: 0.95rem;
-    max-width: 400px;
-    margin: 0 auto;
+  .button-group > * {
+    margin-bottom: 0.5rem;
   }
 
   @media (max-width: 768px) {
-    .settings-icon {
-      width: 40px;
-      height: 40px;
-    }
-
-    .settings-description {
-      font-size: 0.9rem;
-      line-height: 1.5;
-    }
-
-    .mobile-settings-card {
-      margin: 0 0.5rem;
-    }
-  }
-
-  @media (max-width: 576px) {
-    .container-fluid {
-      padding-left: 0.75rem;
-      padding-right: 0.75rem;
-    }
-
     .card-body {
-      padding: 2rem 1.5rem !important;
+      padding: 1.5rem !important;
     }
   }
 </style>


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces a configurable report retention policy to the application, allowing administrators to control how many reports are retained per agent. It includes backend logic to enforce this policy, updates to settings management (including API, DTOs, and database), frontend UI for managing the setting, and comprehensive tests to ensure correct behavior and access control.

**Backend: Report Retention Policy Implementation**
- Added logic to enforce a report retention policy per agent: after each new report, older reports beyond the retention limit are deleted, with the default set to 3 but configurable via settings (`ReportServiceImpl.java`, `Agent.java`). [[1]](diffhunk://#diff-92d95308e6144d443b08b8c2f14f141560569a8eac2b2c369588a625112a3d4cR79-R114) [[2]](diffhunk://#diff-1039a1a58846f8b9a6a8fbb09d18fcc6b41fc981be5249056528e0247d925b62R109-R112)
- Extended `SettingDTO` and related services to support a new `reportRetention` field, including validation and migration to seed the default value (`SettingDTO.java`, `V1.4__add_report_retention_setting.sql`). [[1]](diffhunk://#diff-8a67b0f9429a9b746f8e6563883015d6821b242dfab1cf457c62d83f254f86ffR4-R21) [[2]](diffhunk://#diff-84b7a27a044bce95a4ea60aa06c23b2232d0c1600bc85fa16197d57d51a5fceeR1-R2)

**Backend: Security and API Changes**
- Changed `/api/v1/settings` endpoint to require `ADMIN` role for GET and PATCH requests, tightening security on application settings (`SecurityConfig.java`).

**Frontend: Settings UI and Store**
- Added a new "General Settings" page in the frontend, accessible from the sidebar, allowing admins to view and update the report retention setting (`Settings.vue`, `Sidebar.vue`, `settingsStore.js`). [[1]](diffhunk://#diff-f05df91b30a233adefa5a99bb110ee798ff566460c374abd64083256ee4e2f17R3-R124) [[2]](diffhunk://#diff-8d94685bff01de0ade96fa7e81a2e23e6a9ae1b11847f05ac3ec2c4cabaa18e5R95-R103) [[3]](diffhunk://#diff-a77568a4f761f6f14c33c47ccb871ce12f56788d78dabcde61fe5891c5853880R14-R16) [[4]](diffhunk://#diff-a77568a4f761f6f14c33c47ccb871ce12f56788d78dabcde61fe5891c5853880R48-R83)

**Testing: Backend and Frontend**
- Added and updated tests to verify retention policy enforcement, settings API access control, and correct handling of the new setting, including validation and error cases (`ReportControllerTest.java`, `SettingsControllerTest.java`). [[1]](diffhunk://#diff-b891cf41316651ece97d4de7a6658d129fdfe88887e48191b53ce58658c9f85dR812-R850) [[2]](diffhunk://#diff-a00cd77b4f8227befb6bbb0181edd3c5878ff0b4777486a2682333a5c7af21c3L54-R58) [[3]](diffhunk://#diff-a00cd77b4f8227befb6bbb0181edd3c5878ff0b4777486a2682333a5c7af21c3R68-R106)

**Database Migration**
- Added a migration script to insert the default `reportRetention` setting into the database (`V1.4__add_report_retention_setting.sql`).

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
