### PR TITLE
fix: report epsilon budget

### DIFF
--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ReportServiceImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ReportServiceImpl.java
@@ -16,6 +16,7 @@ import eu.bbmri_eric.quality.agent.dataquality.dto.ReportDTO;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ReportUpdateDTO;
 import eu.bbmri_eric.quality.agent.dataquality.event.NewReportEvent;
 import eu.bbmri_eric.quality.agent.dataquality.exception.ReportNotFoundException;
+import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
@@ -37,16 +38,19 @@ class ReportServiceImpl implements ReportService {
 
   private final ReportRepository reportRepository;
   private final QualityCheckService qualityCheckService;
+  private final SettingsService settingsService;
   private final ModelMapper modelMapper;
   private final EventPublisher publisher;
 
   ReportServiceImpl(
       ReportRepository reportRepository,
       QualityCheckService qualityCheckService,
+      SettingsService settingsService,
       ModelMapper modelMapper,
       EventPublisher publisher) {
     this.reportRepository = reportRepository;
     this.qualityCheckService = qualityCheckService;
+    this.settingsService = settingsService;
     this.modelMapper = modelMapper;
     this.publisher = publisher;
   }
@@ -55,6 +59,7 @@ class ReportServiceImpl implements ReportService {
   @Transactional
   public ReportDTO create(ReportCreateDTO createDTO) {
     Report report = new Report();
+    report.setEpsilonBudget(settingsService.getSettings().getEpsilon());
     report = reportRepository.save(report);
     publisher.publishEvent(new NewReportEvent(report.getId()));
     return modelMapper.map(report, ReportDTO.class);

--- a/agent/backend/src/main/resources/db/dev/migration/R__Test_data.sql
+++ b/agent/backend/src/main/resources/db/dev/migration/R__Test_data.sql
@@ -114,63 +114,63 @@ SELECT name, id, NULL, NULL, 1004, warning_threshold, error_threshold, epsilon_b
 -- Add 10 basic OMOP CDM quality checks
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Missing birth year',
+    ('OMOP: Persons with missing birth year',
      'Persons with missing or null year_of_birth in the OMOP PERSON table',
      'SELECT person_id FROM person WHERE year_of_birth IS NULL',
      'SQL', 10, 50, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Invalid gender concept',
+    ('OMOP: Persons with invalid gender concept',
      'Persons with a gender_concept_id that is not a valid OMOP standard gender concept',
      'SELECT person_id FROM person WHERE gender_concept_id NOT IN (8507, 8532, 8521, 8570, 8551) OR gender_concept_id IS NULL',
      'SQL', 5, 20, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Conditions without concept',
+    ('OMOP: Persons with conditions without concept',
      'Persons who have at least one condition_occurrence record with missing or zero condition_concept_id',
      'SELECT person_id FROM person p WHERE EXISTS (SELECT 1 FROM condition_occurrence c WHERE c.person_id = p.person_id AND (c.condition_concept_id IS NULL OR c.condition_concept_id = 0))',
      'SQL', 10, 100, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Measurements without result',
+    ('OMOP: Persons with measurements without result',
      'Persons who have at least one measurement record with missing result (value_as_number IS NULL AND value_as_concept_id IS NULL)',
      'SELECT person_id FROM person p WHERE EXISTS (SELECT 1 FROM measurement m WHERE m.person_id = p.person_id AND m.value_as_number IS NULL AND m.value_as_concept_id IS NULL)',
      'SQL', 20, 100, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Drug exposures without concept',
+    ('OMOP: Persons with drug exposures without concept',
      'Persons who have at least one drug_exposure record with missing or zero drug_concept_id',
      'SELECT person_id FROM person p WHERE EXISTS (SELECT 1 FROM drug_exposure d WHERE d.person_id = p.person_id AND (d.drug_concept_id IS NULL OR d.drug_concept_id = 0))',
      'SQL', 10, 50, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Visits without end date',
+    ('OMOP: Persons with visits without end date',
      'Persons who have at least one visit_occurrence record with missing visit_end_date',
      'SELECT person_id FROM person p WHERE EXISTS (SELECT 1 FROM visit_occurrence v WHERE v.person_id = p.person_id AND v.visit_end_date IS NULL)',
      'SQL', 15, 50, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Observations without date',
+    ('OMOP: Persons with observations without date',
      'Persons who have at least one observation record with missing observation_date',
      'SELECT person_id FROM person p WHERE EXISTS (SELECT 1 FROM observation o WHERE o.person_id = p.person_id AND o.observation_date IS NULL)',
      'SQL', 10, 50, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Death records without date',
+    ('OMOP: Persons with death records without date',
      'Persons who have a death record with missing death_date',
      'SELECT person_id FROM person p WHERE EXISTS (SELECT 1 FROM death d WHERE d.person_id = p.person_id AND d.death_date IS NULL)',
      'SQL', 1, 5, 0.2);
 
 INSERT INTO quality_check (name, description, query, check_type, warning_threshold, error_threshold, epsilon_budget)
 VALUES
-    ('OMOP: Procedures without concept',
+    ('OMOP: Persons with procedures without concept',
      'Persons who have at least one procedure_occurrence record with missing or zero procedure_concept_id',
      'SELECT person_id FROM person p WHERE EXISTS (SELECT 1 FROM procedure_occurrence pr WHERE pr.person_id = p.person_id AND (pr.procedure_concept_id IS NULL OR pr.procedure_concept_id = 0))',
      'SQL', 10, 50, 0.2);

--- a/agent/frontend/src/views/ReportDetailPage.vue
+++ b/agent/frontend/src/views/ReportDetailPage.vue
@@ -54,6 +54,16 @@
           <StatCard :number="countErrors()" label="Errors" number-class="text-danger" />
           <StatCard :number="countWarnings()" label="Warnings" number-class="text-warning" />
           <StatCard :number="countPassed()" label="Passed" number-class="text-success" />
+          <StatCard
+            :number="formatEpsilon(report.epsilonBudget)"
+            label="Privacy Budget Allocated"
+            number-class="text-primary"
+          />
+          <StatCard
+            :number="formatEpsilon(calculateEpsilonUsed())"
+            label="Privacy Budget Used"
+            :number-class="isOverBudget() ? 'text-danger' : 'text-success'"
+          />
         </div>
 
         <div class="mb-4">
@@ -97,6 +107,14 @@
                           <span class="detail-value">{{
                             formatOccurrenceRate(report, result)
                           }}</span>
+                        </div>
+                        <div v-if="formatPatientCount(result)" class="detail-row">
+                          <span class="detail-label">Number of patients:</span>
+                          <span class="detail-value">{{ formatPatientCount(result) }}</span>
+                        </div>
+                        <div v-if="formatObfuscatedCount(result)" class="detail-row">
+                          <span class="detail-label">Obfuscated:</span>
+                          <span class="detail-value">{{ formatObfuscatedCount(result) }}</span>
                         </div>
                         <div v-if="getResultError(report, result)" class="detail-row">
                           <span class="detail-label text-danger">Error:</span>
@@ -264,9 +282,31 @@
     return result.checkId + '_' + (result.stratum || 'all');
   }
 
+  function formatPatientCount(result) {
+    if (result?.rawValue == null) return null;
+    const val = Number(result.rawValue);
+    return Number.isFinite(val) ? val.toLocaleString() : null;
+  }
+
+  function formatObfuscatedCount(result) {
+    if (result?.obfuscatedValue == null) return null;
+    const val = Number(result.obfuscatedValue);
+    return Number.isFinite(val) ? Math.round(val).toLocaleString() : null;
+  }
+
   const calculateEpsilonUsed = () => {
     if (!report.value?.results) return 0;
-    return report.value.results.reduce((sum, result) => sum + result.epsilon, 0);
+    return report.value.results.reduce((sum, result) => sum + (result.epsilon || 0), 0);
+  };
+
+  const formatEpsilon = (value) => {
+    if (value == null) return '0.00';
+    const num = Number(value);
+    if (!Number.isFinite(num)) return '0.00';
+    return num.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
   };
 
   const isOverBudget = () => {


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces enhancements to both the backend and frontend to support privacy budget (epsilon) tracking for data quality reports, as well as improvements to the clarity of quality check descriptions and the frontend report detail view. The main changes include integrating privacy budget allocation in report creation, displaying privacy budget usage in the UI, and making quality check names more descriptive.

**Backend Enhancements:**

* Privacy budget allocation:
  - The `ReportServiceImpl` now injects `SettingsService` and sets the report's `epsilonBudget` from global settings when creating a new report. [[1]](diffhunk://#diff-caee48d55548505b5862bfd72f7fe4fa29116b54c4385380c117fc07534ec1cfR19) [[2]](diffhunk://#diff-caee48d55548505b5862bfd72f7fe4fa29116b54c4385380c117fc07534ec1cfR41-R53) [[3]](diffhunk://#diff-caee48d55548505b5862bfd72f7fe4fa29116b54c4385380c117fc07534ec1cfR62)

**Frontend Improvements:**

* Privacy budget display:
  - The report detail page now displays both the allocated privacy budget and the amount used, with color indicators for budget overrun. [[1]](diffhunk://#diff-7c5f790262de67d0acc508c5a629b5479b3744024b0c862d3feed08848e6f0f2R57-R66) [[2]](diffhunk://#diff-7c5f790262de67d0acc508c5a629b5479b3744024b0c862d3feed08848e6f0f2R285-R309)
* Result details:
  - The report detail view now shows the number of patients and obfuscated counts for each result, improving transparency of the data shown. [[1]](diffhunk://#diff-7c5f790262de67d0acc508c5a629b5479b3744024b0c862d3feed08848e6f0f2R111-R118) [[2]](diffhunk://#diff-7c5f790262de67d0acc508c5a629b5479b3744024b0c862d3feed08848e6f0f2R285-R309)

**Data Quality Check Naming:**

* Improved clarity:
  - Quality check names in the test data SQL script have been updated to more clearly describe the checks, e.g., "OMOP: Persons with missing birth year" instead of "OMOP: Missing birth year".
### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
