### PR TITLE
feat: add publishing of JAR files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -664,6 +664,46 @@ jobs:
             fi
           done
 
+  publish-jar:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    name: Publish JAR files
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    needs:
+      - test
+      - test-server
+      - integration-test
+      - otel-metrics-push-test
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: 'maven'
+
+      - name: Set artifact version
+        env:
+          ARTIFACT_VERSION: ${{ github.ref_name }}
+        run: |
+          mvn -f agent/backend --quiet -B versions:set -DnewVersion="${ARTIFACT_VERSION//v}"
+          mvn -f server/backend --quiet -B versions:set -DnewVersion="${ARTIFACT_VERSION//v}"
+
+      - name: Publish agent package
+        run: mvn -f agent/backend --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish server package
+        run: mvn -f server/backend --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   integration-test:
     name: System Test
     runs-on: ubuntu-latest

--- a/agent/backend/pom.xml
+++ b/agent/backend/pom.xml
@@ -17,14 +17,6 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/bbmri-cz/data-quality-framework</url>
-        </repository>
-    </repositories>
-
     <properties>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/agent/backend/pom.xml
+++ b/agent/backend/pom.xml
@@ -9,6 +9,22 @@
     <name>Data Quality Metrics Agent</name>
     <description>A data quality tool generating reports with differential privacy</description>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bbmri-cz/data-quality-framework</url>
+        </repository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bbmri-cz/data-quality-framework</url>
+        </repository>
+    </repositories>
+
     <properties>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/server/backend/pom.xml
+++ b/server/backend/pom.xml
@@ -9,6 +9,23 @@
     <packaging>jar</packaging>
     <name>Data Quality Metrics Server</name>
     <description>A data quality central server</description>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bbmri-cz/data-quality-framework</url>
+        </repository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bbmri-cz/data-quality-framework</url>
+        </repository>
+    </repositories>
+
     <properties>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/server/backend/pom.xml
+++ b/server/backend/pom.xml
@@ -18,14 +18,6 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/bbmri-cz/data-quality-framework</url>
-        </repository>
-    </repositories>
-
     <properties>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request introduces automated publishing of JAR files to GitHub Packages when a new tag is pushed, and configures both the agent and server Maven projects to support publishing to GitHub's Maven repository. These changes enable seamless release and distribution of the project's artifacts.

**CI/CD Pipeline Enhancements:**

* Added a new `publish-jar` job to `.github/workflows/ci.yml` that triggers on tag pushes, builds the agent and server JARs, sets their versions according to the tag, and publishes them to GitHub Packages.

**Maven Project Configuration:**

* Updated `agent/backend/pom.xml` to include `distributionManagement` and `repositories` sections for publishing and resolving artifacts from GitHub Packages.
* Updated `server/backend/pom.xml` with similar `distributionManagement` and `repositories` sections for GitHub Packages support.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
