### PR TITLE
fix: add correct Swagger annotations to endpoints

### DIFF
--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/CategoryController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/CategoryController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -29,6 +30,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @RestController
 @RequestMapping("/api/categories")
 @Tag(name = "Categories", description = "API for managing quality check categories")
+@SecurityRequirement(name = "bearerAuth")
 class CategoryController {
 
   private final CategoryService categoryService;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/EntityController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/EntityController.java
@@ -2,6 +2,8 @@ package eu.bbmri_eric.quality.agent.dataquality.controller;
 
 import eu.bbmri_eric.quality.agent.dataquality.DataStore;
 import eu.bbmri_eric.quality.agent.dataquality.DataStoreFactory;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.NoSuchElementException;
 import org.json.JSONObject;
 import org.springframework.http.MediaType;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/entities")
+@Tag(name = "Entities", description = "API for retrieving FHIR entities")
+@SecurityRequirement(name = "bearerAuth")
 class EntityController {
   private final DataStoreFactory dataStoreFactory;
 

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/QualityCheckController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/QualityCheckController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -29,6 +30,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @RestController
 @RequestMapping("/api/quality-checks")
 @Tag(name = "Quality Checks", description = "API for managing Data Quality checks")
+@SecurityRequirement(name = "bearerAuth")
 class QualityCheckController {
 
   private final QualityCheckService qualityCheckService;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/ReportController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/controller/ReportController.java
@@ -5,6 +5,7 @@ import eu.bbmri_eric.quality.agent.dataquality.ReportService;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ReportCreateDTO;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ReportDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -23,6 +24,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @RestController
 @RequestMapping("/api/reports")
 @Tag(name = "Reports", description = "API for managing Data Quality reports")
+@SecurityRequirement(name = "bearerAuth")
 class ReportController {
 
   private final ReportService reportService;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/logs/controller/LogController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/logs/controller/LogController.java
@@ -3,6 +3,7 @@ package eu.bbmri_eric.quality.agent.logs.controller;
 import eu.bbmri_eric.quality.agent.logs.LogService;
 import eu.bbmri_eric.quality.agent.logs.dto.LogEntryDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** REST controller exposing the most recent application logs retained in memory. */
 @RestController
 @Tag(name = "Logs", description = "API for inspecting recent application logs")
+@SecurityRequirement(name = "bearerAuth")
 class LogController {
 
   private final LogService logService;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/server/controller/ServerController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/server/controller/ServerController.java
@@ -10,6 +10,7 @@ import eu.bbmri_eric.quality.agent.server.dto.ServerDto;
 import eu.bbmri_eric.quality.agent.server.dto.ServerUpdateDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/servers")
 @Tag(name = "Server Management", description = "APIs for managing servers")
+@SecurityRequirement(name = "bearerAuth")
 class ServerController {
 
   private final ServerService serverService;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/controller/SettingsController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/settings/controller/SettingsController.java
@@ -3,6 +3,7 @@ package eu.bbmri_eric.quality.agent.settings.controller;
 import eu.bbmri_eric.quality.agent.settings.SettingsService;
 import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/settings")
 @Tag(name = "Settings", description = "Application settings management")
+@SecurityRequirement(name = "bearerAuth")
 class SettingsController {
 
   private final SettingsService settingsService;

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/controller/UserController.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/user/controller/UserController.java
@@ -4,6 +4,7 @@ import eu.bbmri_eric.quality.agent.user.UserService;
 import eu.bbmri_eric.quality.agent.user.dto.PasswordChangeRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Tag(name = "User Management", description = "APIs for user authentication and password management")
+@SecurityRequirement(name = "bearerAuth")
 class UserController {
 
   private final UserService userService;

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/config/OpenApiDocsTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/config/OpenApiDocsTest.java
@@ -1,0 +1,61 @@
+package eu.bbmri_eric.quality.agent.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** Integration tests verifying that the OpenAPI documentation is generated and served. */
+@SpringBootTest
+@AutoConfigureMockMvc
+class OpenApiDocsTest {
+
+  private static final String API_DOCS_ENDPOINT = "/api/api-docs";
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void getApiDocs_withoutAuthentication_shouldReturn200() throws Exception {
+    mockMvc.perform(get(API_DOCS_ENDPOINT)).andExpect(status().isOk());
+  }
+
+  @Test
+  void getApiDocs_shouldContainApiTitle() throws Exception {
+    mockMvc
+        .perform(get(API_DOCS_ENDPOINT))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.info.title").value("Data Quality Agent API"))
+        .andExpect(jsonPath("$.info.version").value("1.0.0"));
+  }
+
+  @Test
+  void getApiDocs_shouldDefineBearerAuthScheme() throws Exception {
+    mockMvc
+        .perform(get(API_DOCS_ENDPOINT))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.components.securitySchemes.bearerAuth.type").value("http"))
+        .andExpect(jsonPath("$.components.securitySchemes.bearerAuth.scheme").value("bearer"))
+        .andExpect(jsonPath("$.components.securitySchemes.bearerAuth.bearerFormat").value("JWT"));
+  }
+
+  @Test
+  void getApiDocs_shouldExposeProtectedEndpoint() throws Exception {
+    mockMvc
+        .perform(get(API_DOCS_ENDPOINT))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.paths./api/categories.get").exists());
+  }
+
+  @Test
+  void getApiDocs_shouldExposePublicLoginEndpoint() throws Exception {
+    mockMvc
+        .perform(get(API_DOCS_ENDPOINT))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.paths./api/auth/login.post").exists());
+  }
+}


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request enhances the OpenAPI documentation for the backend API by explicitly declaring security requirements (bearer authentication) on all major controllers and adding integration tests to verify the generated OpenAPI documentation. These changes ensure that API documentation accurately reflects authentication requirements and that important endpoints and security schemes are correctly exposed.

**OpenAPI Security and Documentation Improvements:**

* Added `@SecurityRequirement(name = "bearerAuth")` annotations to all main controllers (`CategoryController`, `EntityController`, `QualityCheckController`, `ReportController`, `LogController`, `ServerController`, `SettingsController`, `UserController`) to indicate that endpoints require bearer token authentication. [[1]](diffhunk://#diff-9d6d50f0853c55ee9c58f61d6da979be3f2156a5876b1d93752fcdc3e88c7e70R11) [[2]](diffhunk://#diff-9d6d50f0853c55ee9c58f61d6da979be3f2156a5876b1d93752fcdc3e88c7e70R33) [[3]](diffhunk://#diff-e8b05491f4855a45b9ce9a5acbb532d7d3c9276a86ffa9e1d0cf9f9cd67945a2R5-R6) [[4]](diffhunk://#diff-e8b05491f4855a45b9ce9a5acbb532d7d3c9276a86ffa9e1d0cf9f9cd67945a2R18-R19) [[5]](diffhunk://#diff-657c038deba74cbd126009fcc84b113e928a410bf1b03d2c3104328189d98565R12) [[6]](diffhunk://#diff-657c038deba74cbd126009fcc84b113e928a410bf1b03d2c3104328189d98565R33) [[7]](diffhunk://#diff-699568d2e529ed37a346a09cc15df76854837608ca793c69b8186ed916971eadR8) [[8]](diffhunk://#diff-699568d2e529ed37a346a09cc15df76854837608ca793c69b8186ed916971eadR27) [[9]](diffhunk://#diff-27ba5b5294dbf4d3ed342863b0beff0fd556dbab564e5878ee2c5a028cd9e7daR6) [[10]](diffhunk://#diff-27ba5b5294dbf4d3ed342863b0beff0fd556dbab564e5878ee2c5a028cd9e7daR15) [[11]](diffhunk://#diff-d141888b08dc30cd42e17bc008100a32a3e4655b9c270eb43f8fa4f280f769d4R13) [[12]](diffhunk://#diff-d141888b08dc30cd42e17bc008100a32a3e4655b9c270eb43f8fa4f280f769d4R27) [[13]](diffhunk://#diff-f70ee92987fac370571e2be00355a353f29d5c168c08a898f7ab818f5a3c221dR6) [[14]](diffhunk://#diff-f70ee92987fac370571e2be00355a353f29d5c168c08a898f7ab818f5a3c221dR15) [[15]](diffhunk://#diff-c26983ff455b85573f5cef8a735979ef269a24d1c26dfc9a468457dff0bd2c91R7) [[16]](diffhunk://#diff-c26983ff455b85573f5cef8a735979ef269a24d1c26dfc9a468457dff0bd2c91R17)

**Testing and Verification:**

* Introduced `OpenApiDocsTest` integration test class to verify that the OpenAPI documentation is generated, served correctly, includes the expected API title and version, defines the bearer authentication scheme, and exposes both protected and public endpoints.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [x] I have performed a self-review of my code
- [x] I have made my code as simple as possible
- [x] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [x] I have removed all commented code
- [x] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [x] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
