### PR TITLE
fix(agent): do not include PatientIds in Reports by default

### DIFF
--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportResultDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportResultDTO.java
@@ -1,6 +1,5 @@
 package eu.bbmri_eric.quality.agent.dataquality.dto;
 
-import java.util.Set;
 import lombok.Data;
 
 @Data
@@ -15,5 +14,4 @@ public class ReportResultDTO {
   private double epsilon;
   private String error;
   private String stratum;
-  private Set<String> patients;
 }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportResultDetailDTO.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/dto/ReportResultDetailDTO.java
@@ -1,0 +1,11 @@
+package eu.bbmri_eric.quality.agent.dataquality.dto;
+
+import java.util.Set;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ReportResultDetailDTO extends ReportResultDTO {
+  private Set<String> patients;
+}

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ReportServiceImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/ReportServiceImpl.java
@@ -13,6 +13,7 @@ import eu.bbmri_eric.quality.agent.dataquality.dto.QualityCheckDTO;
 import eu.bbmri_eric.quality.agent.dataquality.dto.QualityCheckResultDTO;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ReportCreateDTO;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ReportDTO;
+import eu.bbmri_eric.quality.agent.dataquality.dto.ReportResultDetailDTO;
 import eu.bbmri_eric.quality.agent.dataquality.dto.ReportUpdateDTO;
 import eu.bbmri_eric.quality.agent.dataquality.event.NewReportEvent;
 import eu.bbmri_eric.quality.agent.dataquality.exception.ReportNotFoundException;
@@ -75,7 +76,17 @@ class ReportServiceImpl implements ReportService {
   public ReportDTO findById(Long id) {
     return reportRepository
         .findById(id)
-        .map(report -> modelMapper.map(report, ReportDTO.class))
+        .map(
+            report -> {
+              ReportDTO dto = modelMapper.map(report, ReportDTO.class);
+              dto.setResults(
+                  report.getResults() == null
+                      ? null
+                      : report.getResults().stream()
+                          .map(result -> modelMapper.map(result, ReportResultDetailDTO.class))
+                          .collect(Collectors.toList()));
+              return dto;
+            })
         .orElseThrow(() -> new EntityNotFoundException("Report not found with id: " + id));
   }
 

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/domain/ReportMapperTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/domain/ReportMapperTest.java
@@ -1,10 +1,13 @@
 package eu.bbmri_eric.quality.agent.dataquality.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import eu.bbmri_eric.quality.agent.dataquality.dto.ReportDTO;
+import eu.bbmri_eric.quality.agent.dataquality.dto.ReportResultDTO;
+import eu.bbmri_eric.quality.agent.dataquality.dto.ReportResultDetailDTO;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +77,6 @@ public class ReportMapperTest {
     assertEquals(0.4, firstResult.getEpsilon());
     assertNull(firstResult.getError());
     assertNull(firstResult.getStratum());
-    assertTrue(firstResult.getPatients().containsAll(Set.of("patient-1", "patient-2")));
 
     var secondResult = reportDTO.getResults().get(1);
     assertEquals("Missing Birth Date", secondResult.getCheckName());
@@ -86,7 +88,53 @@ public class ReportMapperTest {
     assertEquals(0.4, secondResult.getEpsilon());
     assertEquals("There is no error message", secondResult.getError());
     assertEquals("stratum_a", secondResult.getStratum());
-    assertEquals(Set.of("patient-3"), secondResult.getPatients());
+  }
+
+  @Test
+  void mapReport_patientsAreNotMappedIntoBaseResultDto() {
+    Report report = new Report();
+    report.setId(106L);
+    report.setResults(
+        new ArrayList<>(
+            List.of(
+                createResult(
+                    "Duplicate Identifier",
+                    31L,
+                    2,
+                    2.0,
+                    10,
+                    30,
+                    0.4,
+                    null,
+                    null,
+                    Set.of("patient-1", "patient-2")))));
+
+    ReportDTO reportDTO = modelMapper.map(report, ReportDTO.class);
+
+    assertThat(reportDTO.getResults().getFirst()).isInstanceOf(ReportResultDTO.class);
+    assertThat(reportDTO.getResults().getFirst()).isNotInstanceOf(ReportResultDetailDTO.class);
+  }
+
+  @Test
+  void mapResult_patientsAreMappedIntoDetailResultDto() {
+    Result result =
+        createResult(
+            "Duplicate Identifier",
+            31L,
+            2,
+            2.0,
+            10,
+            30,
+            0.4,
+            null,
+            null,
+            Set.of("patient-1", "patient-2"));
+
+    ReportResultDetailDTO detailDTO = modelMapper.map(result, ReportResultDetailDTO.class);
+
+    assertEquals("Duplicate Identifier", detailDTO.getCheckName());
+    assertEquals(31L, detailDTO.getCheckId());
+    assertTrue(detailDTO.getPatients().containsAll(Set.of("patient-1", "patient-2")));
   }
 
   @Test


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request refactors how patient information is handled in report result DTOs, introducing a clearer separation between basic and detailed report result data. The main changes involve moving the `patients` field from `ReportResultDTO` to a new subclass, `ReportResultDetailDTO`, updating mapping logic, and enhancing tests to verify this behavior.

**DTO Refactoring:**

* Removed the `patients` field from `ReportResultDTO` and introduced a new subclass `ReportResultDetailDTO` that includes the `patients` field. This clarifies which DTOs contain sensitive patient data and which do not. [[1]](diffhunk://#diff-7619ffdaf8aaef18c7f760298b2300ac43b643ec793973df53e4269db9965eaeL18) [[2]](diffhunk://#diff-904fc93435d019ea22e960d8a18dbbb09f849ca093702acf3e689ff823c258d0R1-R11)

**Mapping Logic Updates:**

* Updated the report retrieval logic in `ReportServiceImpl` so that when fetching a report, its results are now mapped to `ReportResultDetailDTO` objects, ensuring patient data is only present where appropriate.
* Adjusted imports in `ReportServiceImpl` to include the new DTO.

**Testing Enhancements:**

* Updated and expanded tests in `ReportMapperTest` to verify that patient data is only present in `ReportResultDetailDTO` and not in the base `ReportResultDTO`, ensuring correct mapping and data encapsulation. [[1]](diffhunk://#diff-a76c34a90d89ad763df7eca1f17eb81609879bc6113c6cdbf5c515921988dfb2L77) [[2]](diffhunk://#diff-a76c34a90d89ad763df7eca1f17eb81609879bc6113c6cdbf5c515921988dfb2L89-R137) [[3]](diffhunk://#diff-a76c34a90d89ad763df7eca1f17eb81609879bc6113c6cdbf5c515921988dfb2R3-R10)

**Other:**

* Removed an unused import from `ReportResultDTO`.

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [ ] I have performed a self-review of my code
- [ ] I have made my code as simple as possible
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [ ] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
