### PR TITLE
feat(agent): add support for CSV files

### DIFF
--- a/agent/backend/pom.xml
+++ b/agent/backend/pom.xml
@@ -31,6 +31,7 @@
         <hapi.fhir.structures.version>8.8.1</hapi.fhir.structures.version>
         <icd.validator.version>0.1.0</icd.validator.version>
         <commons.compress.version>1.26.1</commons.compress.version>
+        <calcite.version>1.42.0</calcite.version>
         <modelmapper.version>3.2.6</modelmapper.version>
         <jjwt.version>0.13.0</jjwt.version>
         <bouncycastle.version>1.84</bouncycastle.version>
@@ -147,6 +148,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>${commons.compress.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-csv</artifactId>
+            <version>${calcite.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactory.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactory.java
@@ -26,7 +26,7 @@ final class CalciteConnectionFactory {
 
   JdbcTemplate createJdbcTemplate(String url) {
     String resolvedUrl = resolveUrl(url);
-    log.info("Creating Calcite data store for URL: {}", resolvedUrl);
+    log.debug("Creating Calcite data store for URL: {}", url.trim());
     DriverManagerDataSource dataSource = new DriverManagerDataSource();
     dataSource.setUrl(resolvedUrl);
     return new JdbcTemplate(dataSource);

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactory.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactory.java
@@ -1,0 +1,75 @@
+package eu.bbmri_eric.quality.agent.dataquality.impl.store;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/**
+ * Builds a {@link JdbcTemplate} backed by Apache Calcite so that standard SQL data quality checks
+ * can run over CSV files.
+ *
+ * <p>Two connection URL forms are supported:
+ *
+ * <ul>
+ *   <li>{@code jdbc:calcite:model=<model-file>} - a standard Calcite model (JSON/YAML) file that
+ *       references the directory of CSV files.
+ *   <li>{@code jdbc:calcite:directory=<dir>} - a filesystem directory containing CSV files. A CSV
+ *       schema is generated on the fly for that directory.
+ * </ul>
+ */
+@Slf4j
+final class CalciteConnectionFactory {
+
+  private static final String CALCITE_PREFIX = "jdbc:calcite:";
+  private static final String DIRECTORY_PREFIX = CALCITE_PREFIX + "directory=";
+  private static final String MODEL_PREFIX = CALCITE_PREFIX + "model=";
+
+  JdbcTemplate createJdbcTemplate(String url) {
+    String resolvedUrl = resolveUrl(url);
+    log.info("Creating Calcite data store for URL: {}", resolvedUrl);
+    DriverManagerDataSource dataSource = new DriverManagerDataSource();
+    dataSource.setUrl(resolvedUrl);
+    return new JdbcTemplate(dataSource);
+  }
+
+  private String resolveUrl(String url) {
+    if (url == null) {
+      throw new IllegalArgumentException("Calcite JDBC URL must not be null");
+    }
+    String trimmed = url.trim();
+    if (trimmed.startsWith(DIRECTORY_PREFIX)) {
+      String directory = trimmed.substring(DIRECTORY_PREFIX.length()).trim();
+      if (directory.isEmpty()) {
+        throw new IllegalArgumentException("Calcite JDBC URL is missing the CSV directory");
+      }
+      return buildInlineModelUrl(directory);
+    }
+    if (trimmed.startsWith(MODEL_PREFIX)) {
+      return trimmed;
+    }
+    throw new IllegalArgumentException(
+        "Unsupported Calcite JDBC URL: "
+            + url
+            + ". Expected jdbc:calcite:model=... or jdbc:calcite:directory=...");
+  }
+
+  private String buildInlineModelUrl(String directory) {
+    String modelJson =
+        "{"
+            + "\"version\":\"1.0\","
+            + "\"defaultSchema\":\"CSV\","
+            + "\"schemas\":[{"
+            + "\"name\":\"CSV\","
+            + "\"type\":\"custom\","
+            + "\"factory\":\"org.apache.calcite.adapter.csv.CsvSchemaFactory\","
+            + "\"operand\":{\"directory\":\""
+            + escape(directory)
+            + "\"}"
+            + "}]}";
+    return CALCITE_PREFIX + "model=inline:" + modelJson + ";lex=MYSQL";
+  }
+
+  private static String escape(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+}

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactory.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactory.java
@@ -70,6 +70,11 @@ final class CalciteConnectionFactory {
   }
 
   private static String escape(String value) {
-    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    return value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t");
   }
 }

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/DataStoreFactoryImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/DataStoreFactoryImpl.java
@@ -69,8 +69,9 @@ class DataStoreFactoryImpl implements DataStoreFactory {
 
   private OmopDataStore createSqlDataStore(SettingsDTO settings) {
     String url = settings.getSqlUrl();
-    if (url != null && url.startsWith("jdbc:calcite:")) {
-      return new OmopDataStore(new CalciteConnectionFactory().createJdbcTemplate(url));
+    String trimmedUrl = url != null ? url.trim() : null;
+    if (trimmedUrl != null && trimmedUrl.startsWith("jdbc:calcite:")) {
+      return new OmopDataStore(new CalciteConnectionFactory().createJdbcTemplate(trimmedUrl));
     }
     DriverManagerDataSource dataSource = new DriverManagerDataSource();
     dataSource.setUrl(settings.getSqlUrl());

--- a/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/DataStoreFactoryImpl.java
+++ b/agent/backend/src/main/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/DataStoreFactoryImpl.java
@@ -68,6 +68,10 @@ class DataStoreFactoryImpl implements DataStoreFactory {
   }
 
   private OmopDataStore createSqlDataStore(SettingsDTO settings) {
+    String url = settings.getSqlUrl();
+    if (url != null && url.startsWith("jdbc:calcite:")) {
+      return new OmopDataStore(new CalciteConnectionFactory().createJdbcTemplate(url));
+    }
     DriverManagerDataSource dataSource = new DriverManagerDataSource();
     dataSource.setUrl(settings.getSqlUrl());
     dataSource.setUsername(settings.getSqlUsername());

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactoryTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/CalciteConnectionFactoryTest.java
@@ -1,0 +1,52 @@
+package eu.bbmri_eric.quality.agent.dataquality.impl.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class CalciteConnectionFactoryTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void directoryUrl_runsSqlQueriesOverCsvFiles() throws Exception {
+    Files.writeString(
+        tempDir.resolve("person.csv"),
+        "\"person_id\",\"name\",\"age\"\n\"1\",\"Alice\",\"30\"\n\"2\",\"Bob\",\"25\"\n");
+    CalciteConnectionFactory factory = new CalciteConnectionFactory();
+    JdbcTemplate jdbcTemplate =
+        factory.createJdbcTemplate("jdbc:calcite:directory=" + tempDir.toAbsolutePath());
+
+    Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM person", Integer.class);
+    assertEquals(2, count);
+  }
+
+  @Test
+  void directoryUrl_executesScalarCount() throws Exception {
+    Files.writeString(tempDir.resolve("person.csv"), "\"person_id\"\n\"1\"\n\"2\"\n\"3\"\n");
+    CalciteConnectionFactory factory = new CalciteConnectionFactory();
+    JdbcTemplate jdbcTemplate =
+        factory.createJdbcTemplate("jdbc:calcite:directory=" + tempDir.toAbsolutePath());
+
+    Long count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM person", Long.class);
+    assertEquals(3, count);
+  }
+
+  @Test
+  void invalidUrl_throws() {
+    CalciteConnectionFactory factory = new CalciteConnectionFactory();
+    assertThrows(
+        IllegalArgumentException.class, () -> factory.createJdbcTemplate("jdbc:postgresql://x"));
+  }
+
+  @Test
+  void nullUrl_throws() {
+    CalciteConnectionFactory factory = new CalciteConnectionFactory();
+    assertThrows(IllegalArgumentException.class, () -> factory.createJdbcTemplate(null));
+  }
+}

--- a/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/DataStoreFactoryImplTest.java
+++ b/agent/backend/src/test/java/eu/bbmri_eric/quality/agent/dataquality/impl/store/DataStoreFactoryImplTest.java
@@ -1,0 +1,57 @@
+package eu.bbmri_eric.quality.agent.dataquality.impl.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+import eu.bbmri_eric.quality.agent.dataquality.DataStore;
+import eu.bbmri_eric.quality.agent.settings.DatabaseType;
+import eu.bbmri_eric.quality.agent.settings.SettingsService;
+import eu.bbmri_eric.quality.agent.settings.dto.SettingsDTO;
+import eu.bbmri_eric.quality.agent.settings.event.SettingsUpdatedEvent;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+
+class DataStoreFactoryImplTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void calciteDirectoryUrl_resolvesToSqlDataStoreOverCsv() throws Exception {
+    Files.writeString(
+        tempDir.resolve("person.csv"),
+        "\"person_id\",\"name\"\n\"1\",\"Alice\"\n\"2\",\"Bob\"\n\"3\",\"Chad\"\n");
+    DataStoreFactoryImpl factory =
+        new DataStoreFactoryImpl(mock(SettingsService.class), mock(RestTemplateBuilder.class));
+    SettingsDTO settings =
+        SettingsDTO.builder()
+            .databaseType(DatabaseType.SQL)
+            .sqlUrl("jdbc:calcite:directory=" + tempDir.toAbsolutePath())
+            .build();
+    factory.onSettingsUpdated(new SettingsUpdatedEvent(settings));
+
+    DataStore store = factory.resolveDataStore();
+    assertInstanceOf(OmopDataStore.class, store);
+    OmopDataStore omop = (OmopDataStore) store;
+    assertEquals(3, omop.countPatients());
+  }
+
+  @Test
+  void nonCalciteUrl_usesDriverManagerDataSource() {
+    DataStoreFactoryImpl factory =
+        new DataStoreFactoryImpl(mock(SettingsService.class), mock(RestTemplateBuilder.class));
+    SettingsDTO settings =
+        SettingsDTO.builder()
+            .databaseType(DatabaseType.SQL)
+            .sqlUrl("jdbc:postgresql://localhost:5432/quality")
+            .sqlUsername("user")
+            .build();
+    factory.onSettingsUpdated(new SettingsUpdatedEvent(settings));
+
+    DataStore store = factory.resolveDataStore();
+    assertInstanceOf(OmopDataStore.class, store);
+  }
+}

--- a/agent/frontend/src/components/settings/SqlSettingsFields.vue
+++ b/agent/frontend/src/components/settings/SqlSettingsFields.vue
@@ -5,7 +5,7 @@
     label="SQL JDBC URL"
     icon="bi-link-45deg"
     placeholder="jdbc:postgresql://localhost:5432/quality"
-    help-text="The JDBC connection string for the SQL database"
+    help-text="JDBC connection string (e.g. Postgres). To query CSV files instead, use jdbc:calcite:directory=/path/to/csvs"
     :required="required"
   />
 
@@ -15,8 +15,8 @@
     label="SQL Username"
     icon="bi-person"
     placeholder="Enter username"
-    help-text="Username for authenticating with the SQL database"
-    :required="required"
+    help-text="Not required for CSV (Calcite) connections"
+    :required="required && !isCalcite"
     autocomplete="username"
   />
 
@@ -27,14 +27,14 @@
     label="SQL Password"
     icon="bi-key"
     placeholder="Enter password"
-    help-text="Password for authenticating with the SQL database"
-    :required="required"
+    help-text="Not required for CSV (Calcite) connections"
+    :required="required && !isCalcite"
     autocomplete="current-password"
   />
 </template>
 
 <script setup>
-  import { toRef } from 'vue';
+  import { computed, toRef } from 'vue';
   import { FormField } from '@/components/forms';
 
   const props = defineProps({
@@ -49,4 +49,6 @@
   });
 
   const settings = toRef(props, 'settings');
+
+  const isCalcite = computed(() => (settings.value.url || '').startsWith('jdbc:calcite:'));
 </script>

--- a/agent/frontend/src/views/DifferentialPrivacyPage.vue
+++ b/agent/frontend/src/views/DifferentialPrivacyPage.vue
@@ -21,6 +21,15 @@
                   Configure the differential privacy settings to balance data utility and privacy
                   protection
                 </p>
+                <a
+                  class="docs-link"
+                  href="https://fdqf.bbmri-eric.eu/user/privacy-configuration"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Documentation
+                  <i class="bi bi-box-arrow-up-right"></i>
+                </a>
               </div>
             </div>
 
@@ -240,6 +249,21 @@
 
   .section-title i {
     color: var(--color-primary);
+  }
+
+  .docs-link {
+    color: var(--color-primary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.875rem;
+    margin-top: var(--spacing-xs);
+    flex-shrink: 0;
+  }
+
+  .docs-link:hover {
+    text-decoration: underline;
   }
 
   .settings-form {

--- a/agent/frontend/src/views/SettingsPage.vue
+++ b/agent/frontend/src/views/SettingsPage.vue
@@ -22,6 +22,15 @@
                 <p class="text-muted mb-0">
                   Choose the data source and configure the connection details
                 </p>
+                <a
+                  class="docs-link"
+                  href="https://fdqf.bbmri-eric.eu/user/data-sources"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Documentation
+                  <i class="bi bi-box-arrow-up-right"></i>
+                </a>
               </div>
             </div>
 
@@ -197,6 +206,21 @@
 
   .section-title i {
     color: var(--color-primary);
+  }
+
+  .docs-link {
+    color: var(--color-primary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.875rem;
+    margin-top: var(--spacing-xs);
+    flex-shrink: 0;
+  }
+
+  .docs-link:hover {
+    text-decoration: underline;
   }
 
   .settings-form {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -62,6 +62,7 @@ export default defineConfig({
                             items: [
                                 {text: 'Configuration', link: '/user/configuration'},
                                 {text: 'Data Sources', link: '/user/data-sources'},
+                                {text: 'Privacy Configuration', link: '/user/privacy-configuration'},
                             ]
                         },
                         {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -61,6 +61,7 @@ export default defineConfig({
                             text: 'Data Quality Agent',
                             items: [
                                 {text: 'Configuration', link: '/user/configuration'},
+                                {text: 'Data Sources', link: '/user/data-sources'},
                             ]
                         },
                         {

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -96,6 +96,27 @@ Additionally, as described above, you can override any internal application sett
 
 By using environment variables, you can fully automate the configuration of your Data Quality Agent during deployment.
 
+## Connecting to CSV files (Apache Calcite)
+
+When `sqlUrl` points to a directory of CSV files (see [Data Sources](./data-sources.md)), the agent reads them from a path **inside the container**. You must therefore mount the folder that contains the CSV files into the agent container so that the JDBC URL resolves to a valid location.
+
+For example, to make `/opt/omop/csv` on the host available at the same path inside the container:
+
+```yaml
+services:
+  quality-agent:
+    image: ghcr.io/bbmri-cz/data-quality-agent:latest
+    volumes:
+      - /opt/omop/csv:/opt/omop/csv:ro
+    environment:
+      - APP_SETTING_DATABASE_TYPE=SQL
+      - APP_SETTING_SQL_URL=jdbc:calcite:directory=/opt/omop/csv
+```
+
+Then place your CSV files (one table per file, with a header row) directly in the mounted folder, e.g. `person.csv`, `specimen.csv`.
+
+The folder can be mounted read-only (`:ro`) since the agent only reads the files. Choose any mount path, but it must match the directory referenced after `jdbc:calcite:directory=` in `sqlUrl`.
+
 ## Proxy Configuration
 
 If the agent must reach external services through an HTTP/HTTPS proxy (for example a corporate firewall that governs access to the FHIR server, the central reporting server, or the OTLP metrics endpoint), you can configure the Java Virtual Machine to route outbound connections through the proxy.

--- a/docs/user/data-sources.md
+++ b/docs/user/data-sources.md
@@ -1,0 +1,84 @@
+# Data Sources
+
+The Data Quality Agent connects to a data source and runs data quality checks against it. The `databaseType` setting selects between two families:
+
+- **FHIR** — a FHIR R4 server queried with CQL.
+- **SQL** — a relational database or a directory of CSV files queried with SQL.
+
+## FHIR servers
+
+When `databaseType` is `FHIR`, the agent acts as a FHIR R4 REST client and runs CQL checks against the configured server:
+
+| Setting          | Description                                                        |
+|:-----------------|:-------------------------------------------------------------------|
+| `fhirUrl`        | Base URL of the FHIR R4 server (e.g. `http://localhost:8080/fhir`). |
+| `fhirUsername`   | Optional username for basic authentication.                        |
+| `fhirPassword`   | Optional password for basic authentication (Base64 encoded).       |
+
+Only the `databaseType=FHIR` configuration is required to use this data source; the agent connects to the server at `fhirUrl` and authenticates with the provided credentials when given.
+
+## SQL driver selection
+
+When `databaseType` is `SQL`, the agent looks at the JDBC URL (`sqlUrl`):
+
+- **URLs starting with `jdbc:calcite:`** are handled by Apache Calcite. Only two sub-forms are accepted (see below); anything else under that prefix is rejected.
+- **Any other `jdbc:` URL** is passed to the standard JDBC `DriverManager` and uses whichever driver is on the classpath. The agent ships with these drivers bundled:
+
+| JDBC URL prefix               | Driver / engine          |
+|:------------------------------|:-------------------------|
+| `jdbc:postgresql://...`       | PostgreSQL               |
+| `jdbc:mysql://...`            | MySQL                    |
+| `jdbc:sqlite:...`             | SQLite                   |
+| `jdbc:calcite:directory=<dir>`| Apache Calcite / CSV      |
+
+For the standard JDBC URLs the agent connects using the supplied username/password. Additional database drivers can be supported by adding them to the agent's classpath — no code change is required, since these URLs simply go through `DriverManager`.
+
+## Querying CSV files with Calcite
+
+Only these two Calcite URL forms are supported:
+
+| Form                              | Purpose                                              |
+|:----------------------------------|:-----------------------------------------------------|
+| `jdbc:calcite:directory=<dir>`    | Query a directory of CSV files (auto-generated model) |
+| `jdbc:calcite:model=<model-file>` | Query using a custom Calcite JSON/YAML model file     |
+
+
+**Example**
+
+```
+databaseType: SQL
+sqlUrl: jdbc:calcite:directory=/opt/omop/csv
+```
+
+If `/opt/omop/csv/person.csv` and `/opt/omop/csv/specimen.csv` exist, checks such as `SELECT COUNT(*) FROM person` work as expected.
+
+### CSV conventions
+
+- **Header row**: the first row must be the column names; column types are inferred from the values.
+- **Table names**: each file becomes a table named after the file's base name (e.g. `person.csv` → `person`).
+- **Case sensitivity**: the `directory=` form uses `lex=MYSQL`, so unquoted identifiers are matched case-insensitively and the common OMOP lowercase style (`person`, `specimen`) works out of the box.
+
+### Custom model file
+
+For more control (custom delimiters, explicit schemas, multiple directories), use a standard Calcite model file instead:
+
+```json
+{
+  "version": "1.0",
+  "defaultSchema": "CSV",
+  "schemas": [
+    {
+      "name": "CSV",
+      "type": "custom",
+      "factory": "org.apache.calcite.adapter.csv.CsvSchemaFactory",
+      "operand": { "directory": "/opt/omop/csv" }
+    }
+  ]
+}
+```
+
+```
+sqlUrl: jdbc:calcite:model=/opt/omop/model.json
+```
+
+Note that with a custom model file, identifier quoting and case-sensitivity follow the conventions defined by the model rather than the defaults applied automatically to the `directory=` form.

--- a/docs/user/privacy-configuration.md
+++ b/docs/user/privacy-configuration.md
@@ -1,0 +1,21 @@
+# Privacy Configuration
+
+The agent applies **differential privacy** to the quality metrics it reports, so only privacy-protected aggregates ever leave your site. The privacy parameters are configured on the **Differential Privacy** page of the agent UI and can also be set through environment variables. For a general introduction to how the framework protects data, see the [Privacy & Security](./privacy.md) page.
+
+## Settings
+
+| Setting          | Description                                                                                                                          | Default     | Validation                            |
+|:-----------------|:-------------------------------------------------------------------------------------------------------------------------------------|:------------|:--------------------------------------|
+| `epsilon`        | Privacy budget (ε). Smaller values mean stronger privacy but add more noise to results.                                              | `3.0`       | `> 0`                                 |
+| `delta`          | Delta parameter (δ) — probability of privacy failure. Typically a very small value such as `1e-8`.                                   | `1e-8`      | `> 0`                                 |
+| `minThreshold`   | Minimum count threshold for low count suppression. Reported values below this are hidden.                                            | `50`        | `>= 0`                                |
+| `noiseMechanism` | Noise distribution used. One of `LAPLACE` or `GAUSSIAN`.                                                                             | `LAPLACE`   | `LAPLACE` or `GAUSSIAN`               |
+
+### Noise mechanisms
+
+- **Laplace**: adds noise from a Laplace distribution. Best for unbounded queries and provides (ε, 0)-differential privacy.
+- **Gaussian**: adds noise from a Gaussian (normal) distribution. Used for (ε, δ)-differential privacy where δ > 0. Provides better utility for bounded queries with the same privacy guarantee.
+
+::: warning Gaussian constraint
+When `noiseMechanism` is `GAUSSIAN`, `epsilon` must be `<= 1.0`. If you need a larger privacy budget, use `LAPLACE`.
+:::


### PR DESCRIPTION
## Pull Request:

### Description:

This pull request adds support for using Apache Calcite to run SQL data quality checks directly over directories of CSV files, in addition to traditional SQL databases. It enables users to specify a CSV directory in the JDBC URL, and the backend and frontend are updated to support and explain this new mode. Documentation is expanded to guide users through configuration and data source selection, including CSV/Calcite usage and privacy settings.

**Backend: Calcite/CSV Data Source Support**
- Added Apache Calcite as a dependency and implemented `CalciteConnectionFactory` to create `JdbcTemplate` instances for Calcite-backed CSV directories or model files. This allows SQL queries to be run directly on CSV files via Calcite. (`pom.xml`, `CalciteConnectionFactory.java`) [[1]](diffhunk://#diff-fbfbd50f0d0e5f0d58b519976012411cd58df6819ddc32e5e8668c6e56131db5R34) [[2]](diffhunk://#diff-fbfbd50f0d0e5f0d58b519976012411cd58df6819ddc32e5e8668c6e56131db5R152-R156) [[3]](diffhunk://#diff-229c71cb525b7e884e768434312048e9189f0b904e5a75d6b5d5be28a40ce6a5R1-R75)
- Modified `DataStoreFactoryImpl` to detect `jdbc:calcite:` URLs and use `CalciteConnectionFactory`, enabling seamless switching between SQL databases and CSV files as data sources.
- Added comprehensive tests for Calcite connection creation and integration in the data store factory. (`CalciteConnectionFactoryTest.java`, `DataStoreFactoryImplTest.java`) [[1]](diffhunk://#diff-ec86e387ab25e86b72cd87a737c5083df0b0841743abfc31e5bd61ab63063446R1-R52) [[2]](diffhunk://#diff-1b22d78aada6395f27e58f91142e539bdd7050508db5e495e6b493ec0c45e75aR1-R57)

**Frontend: Improved SQL Settings UX**
- Updated SQL settings fields to clarify CSV/Calcite usage, dynamically adjust required fields, and provide contextual help for users connecting to CSV files. (`SqlSettingsFields.vue`) [[1]](diffhunk://#diff-4f30e209e51a650273a29c7a47e196f94a9cdbbb1ccc9c24da2af7f222fb2e92L8-R8) [[2]](diffhunk://#diff-4f30e209e51a650273a29c7a47e196f94a9cdbbb1ccc9c24da2af7f222fb2e92L18-R19) [[3]](diffhunk://#diff-4f30e209e51a650273a29c7a47e196f94a9cdbbb1ccc9c24da2af7f222fb2e92L30-R37) [[4]](diffhunk://#diff-4f30e209e51a650273a29c7a47e196f94a9cdbbb1ccc9c24da2af7f222fb2e92R52-R53)

**Documentation: Data Sources, CSV/Calcite, and Privacy**
- Added detailed documentation on data source configuration, including a new page for data sources and a section on connecting to CSV files with Calcite, with examples for containerized deployments. (`data-sources.md`, `configuration.md`) [[1]](diffhunk://#diff-e3c69f2e6473b5505915f18e91988c6a517d642b3d3cc89235fecc091ac4af4aR1-R84) [[2]](diffhunk://#diff-02902b8e3d833d54327a21129673fa370949804a6c4e164ec6c479e0f093ad9cR99-R119)
- Added a new privacy configuration documentation page and linked relevant documentation from the UI for both data sources and privacy configuration. (`privacy-configuration.md`, `DifferentialPrivacyPage.vue`, `SettingsPage.vue`, `.vitepress/config.js`) [[1]](diffhunk://#diff-5b068ead2cd22d3c78626b7d7b1a052a3e7e12ff32b07e8af22ff4e4ea22d6f9R1-R21) [[2]](diffhunk://#diff-9e5660f74906d6c2779747487c811940f4e383b8adff5416e961d587b6afc359R24-R32) [[3]](diffhunk://#diff-9e5660f74906d6c2779747487c811940f4e383b8adff5416e961d587b6afc359R254-R268) [[4]](diffhunk://#diff-7b75270ff20e4150ea42abf050eec477ab49fb23aa04a0450f4b0185734c351fR25-R33) [[5]](diffhunk://#diff-7b75270ff20e4150ea42abf050eec477ab49fb23aa04a0450f4b0185734c351fR211-R225) [[6]](diffhunk://#diff-0a4e5303994d6be8e931143d050187fa18a698da42955821d63b7b70e5a451c9R64-R65)

### Checklist:

_Make sure you tick all the boxes below if they are true or do not apply before you ask for review_

- [ ] I have performed a self-review of my code
- [ ] I have made my code as simple as possible
- [ ] I have added relevant tests for my changes and the code coverage has not dropped substantially
- [ ] I have removed all commented code
- [ ] I have updated the documentation in all relevant places (Javadoc, Swagger, MDs...)
- [ ] I have described the PR and added a meaningful title in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
